### PR TITLE
Allow contextDependencies to be specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var nutil = require('util');
 var utils = require('loader-utils');
 var sass = require('node-sass');
 var path = require('path');
@@ -11,7 +12,17 @@ module.exports = function(content) {
   var callback = this.async();
 
   var opt = utils.parseQuery(this.query);
-  opt.data = content; 
+  opt.data = content;
+
+  if (opt.contextDependencies) {
+    if (!nutil.isArray(opt.contextDependencies)) {
+      opt.contextDependencies = [opt.contextDependencies]
+    }
+    var loaderContext = this;
+    opt.contextDependencies.forEach(function(d) {
+      loaderContext.addContextDependency(d);
+    });
+  }
   
   // set include path to fix imports
   opt.includePaths = opt.includePaths || [];


### PR DESCRIPTION
Until https://github.com/jtangelder/sass-loader/issues/2 is resolved, this is a workaround to specify sass dependencies so the build can be invalidated.
