### PR TITLE
Include an example of how to includePaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ module.exports = {
     loaders: [
       {
         test: /\.scss$/,
-        loader: "style!css!sass?outputStyle=expanded"
+        loader: "style!css!sass?outputStyle=expanded&includePaths[]=" + 
+            (path.resolve(__dirname, './bower_components/bootstrap-sass-official'))
       }
     ]
   }


### PR DESCRIPTION
Trying to figure out how to pass it through isn't obvious looking through the docs or the source. Had to https://github.com/webpack/loader-utils/ to find out the exact syntax. This would have really helped.
