### PR TITLE
emit compilation error for better feedback

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,9 @@ module.exports = function (content) {
     }.bind(this);
 
     opt.error = function (err) {
+        this.emitError(err);
         callback(err);
-    };
+    }.bind(this);
 
     sass.render(opt);
 };


### PR DESCRIPTION
Webpack apparently aims for brevity in build errors, unless they're specifically emitted as an error. This change gives the user some more context of what exactly went wrong, instead of just where the problem was.
