### PR TITLE
Use sass stats for marking dependencies instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@ var util = require('util');
 var utils = require('loader-utils');
 var sass = require('node-sass');
 var path = require('path');
-var sassGraph = require('sass-graph');
-
 
 module.exports = function (content) {
     this.cacheable();
@@ -29,13 +27,9 @@ module.exports = function (content) {
     opt.outputStyle = opt.outputStyle || 'compressed';
     opt.stats = {};
 
-    // mark dependencies
-    var graph = sassGraph.parseFile(this.resourcePath, {loadPaths: opt.includePaths});
-    graph.visitDescendents(this.resourcePath, function (imp) {
-        this.addDependency(imp);
-    }.bind(this));
-
     opt.success = function (css) {
+        // mark dependencies
+        opt.stats.includedFiles.forEach(this.addDependency);
         callback(null, css);
     }.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "~0.2.2",
-    "node-sass": "^1.0.1",
-    "sass-graph": "^0.1.2"
+    "node-sass": "^1.0.1"
   },
   "devDependencies": {
     "css-loader": "^0.9.0",


### PR DESCRIPTION
I think we should be using the stats provided by sass compiler in order to mark the dependencies.
It contains all includedFiles which is exactly what webpack needs to know about.

Pro's:
Cleaner code
Removed one external dependency (sass-graph)
Better performance
Windows compatibility (sass-graph has issues regarding this)

Con's:
None that I've found. Please do tell if I missed something crucial.
