### PR TITLE
feat(index): add `noImporter` option (`options.noImporter`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Alternatively, for bootstrap-sass:
 
 It's important to only prepend it with `~`, because `~/` resolves to the home directory. webpack needs to distinguish between `bootstrap` and `~bootstrap` because CSS and Sass files have no special syntax for importing relative files. Writing `@import "file"` is the same as `@import "./file";`
 
+### Disabling imports for faster compile time
+
+Function calls associated with the advanced file resolution described above can add up to a significant time on projects with a large number of scss files.
+E.g. on a project with some 130 components each requiring an .scss file, sass build took 240 seconds with the importer, and 3 seconds without. To disable the
+advanced import resolution, pass `noImporter: true` in the `sassLoader` options.
+
+
 ### Environment variables
 
 If you want to prepend Sass code before the actual entry file, you can simply set the `data` option. In this case, the sass-loader will not override the `data` option but just append the entry's content. This is especially useful when some of your Sass variables depend on the environment:

--- a/index.js
+++ b/index.js
@@ -249,6 +249,12 @@ module.exports = function (content) {
     sassOptions.importer = sassOptions.importer ? proxyCustomImporters(sassOptions.importer, resourcePath) : [];
     sassOptions.importer.push(getWebpackImporter());
 
+    // For larger projects, using the webpack importer can really add up: 4 minutes versus 3 seconds on a
+    // modest project with a 130 components and a dozen common definition files required in each scss file
+    if (sassOptions.noImporter === true) {
+        sassOptions.importer = undefined;
+    }
+
     // `node-sass` uses `includePaths` to resolve `@import` paths. Append the currently processed file.
     sassOptions.includePaths = sassOptions.includePaths ? [].concat(sassOptions.includePaths) : [];
     sassOptions.includePaths.push(path.dirname(resourcePath));


### PR DESCRIPTION
Function calls associated with the advanced file resolution described above can add up to a significant time on projects with a large number of scss files. On a project with some 130 components each requiring an .scss file, sass build took 240 seconds with the importer, and 3 seconds without.

Everything below is my attempt at keyword bait for the next unfortunate soul dealing with this issue, as it took me half a day to figure out which part of the webpack pipeline is responsible for the slowness.

webpack 2, css-loader, sass-loader, style-loader, ExtractTextPlugin, extract-text-webpack-plugin, slow large project, many imports, require .sass from .js, super-slow, really slow, insanely slow
