### PR TITLE
Add Comment as `content` default

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -21,6 +21,7 @@ const asyncSassJobQueue = async.queue(sass.render, threadPoolSize - 1);
  * @param {string} content
  */
 function sassLoader(content) {
+    content = content || '//';
     const callback = this.async();
     const isSync = typeof callback !== "function";
     const self = this;


### PR DESCRIPTION
Without it, an empty file will throw the following error:

```
Module build failed: No input specified: provide a file name or a source string to process
```

In my case, I'm loading third-party components which always include an accompanying `.css` file, but aren't all populated. 

By adding a comment as a (harmless) fallback, empty files are easily "ignored". 