### PR TITLE
Don't add dependency for path handled by custom importer

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -28,7 +28,9 @@ function sassLoader(content) {
 
     function addNormalizedDependency(file) {
         // node-sass returns POSIX paths
-        self.dependency(path.normalize(file));
+        if (path.isAbsolute(file)) {
+            self.dependency(path.normalize(file));
+        }
     }
 
     if (isSync) {


### PR DESCRIPTION
When using webpack-dev-server currently sass-loader needs to rebuild sass files when they use a custom importer function that returns content.

The (relative) path is added as dependency although the file doesn't exist at all.

This change adds only absolute paths (as returned by node-sass in stats) as dependencies.