### PR TITLE
moved node-sass to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "clone-deep": "^0.2.4",
     "loader-utils": "^1.0.1",
     "lodash.tail": "^4.1.1",
-    "pify": "^2.3.0"
+    "pify": "^2.3.0",
+    "node-sass": "^4.0.0"
   },
   "devDependencies": {
     "bootstrap-sass": "^3.3.5",


### PR DESCRIPTION
Not sure if this is a good idea or not, but I had to do this in order to get webpack working locally so I figured I'd submit it. I was getting errors about missing a particular version of node-sass, so it seemed like it should just be a requirement of this module.