### PR TITLE
change bootstrap path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ module.exports = {
 webpack provides an [advanced mechanism to resolve files](http://webpack.github.io/docs/resolving.html). The sass-loader uses node-sass' custom importer feature to pass all queries to the webpack resolving engine. Thus you can import your Sass modules from `node_modules`. Just prepend them with a `~` to tell webpack that this is not a relative import:
 
 ```css
-@import "~bootstrap/css/bootstrap";
+@import "~bootstrap/dist/css/bootstrap";
 ```
 
 It's important to only prepend it with `~`, because `~/` resolves to the home directory. webpack needs to distinguish between `bootstrap` and `~bootstrap` because CSS and Sass files have no special syntax for importing relative files. Writing `@import "file"` is the same as `@import "./file";`


### PR DESCRIPTION
I think the bootstrap path in the documentation is wrong  according to the current bootstrap folder structure(https://cl.ly/1j1W3C0l3z2N) the right path would be `bootstrap/dist/css/bootstrap`