### PR TITLE
fix: importing file directly from scoped npm package

### DIFF
--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -40,7 +40,7 @@ function importsToResolve(request) {
         // (i.e. @pkg/foo/file), if so, process import as file import;
         // otherwise, if we import from root npm scoped package (i.e. @pkg/foo)
         // process import as a module import.
-        isModuleImport = !(dirname.indexOf(path.sep) > -1);
+        isModuleImport = !(dirname.indexOf("/") > -1);
     }
 
     return (isModuleImport && [request]) || // Do not modify module imports

--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -28,12 +28,20 @@ function importsToResolve(request) {
     const basename = path.basename(request);
     const dirname = path.dirname(request);
     const startsWithUnderscore = basename.charAt(0) === "_";
-    // a module import is an identifier like 'bootstrap-sass'
-    // Firstly check whether we importing scoped npm package (i.e. "@org/pkg")
-    // We also need to check for dirname since it might also be a deep import like 'bootstrap-sass/something'
-    const isModuleImport = dirname.charAt(0) === "@" && dirname.length > 1 ? true : request.charAt(0) !== "." && dirname === ".";
     const hasCssExt = ext === ".css";
     const hasSassExt = ext === ".scss" || ext === ".sass";
+
+    // a module import is an identifier like 'bootstrap-sass'
+    // We also need to check for dirname since it might also be a deep import like 'bootstrap-sass/something'
+    let isModuleImport = request.charAt(0) !== "." && dirname === ".";
+
+    if (dirname.charAt(0) === "@") {
+        // Check whether it is a deep import from scoped npm package
+        // (i.e. @pkg/foo/file), if so, process import as file import;
+        // otherwise, if we import from root npm scoped package (i.e. @pkg/foo)
+        // process import as a module import.
+        isModuleImport = !(dirname.indexOf(path.sep) > -1);
+    }
 
     return (isModuleImport && [request]) || // Do not modify module imports
         (hasCssExt && []) || // Do not import css files

--- a/test/node_modules/@org/bar/_foo.scss
+++ b/test/node_modules/@org/bar/_foo.scss
@@ -1,0 +1,3 @@
+.scoped-npm-pkg-foo {
+    background: black;
+}

--- a/test/sass/import-from-npm-org-pkg.sass
+++ b/test/sass/import-from-npm-org-pkg.sass
@@ -1,5 +1,7 @@
-/* @import "~@org/pkg"; */
-@import "~@org/pkg";
+/* @import ~@org/pkg */
+@import ~@org/pkg
+/* @import ~@org/bar/foo */
+@import ~@org/bar/foo
 
 .foo
     background: #000;

--- a/test/scss/import-from-npm-org-pkg.scss
+++ b/test/scss/import-from-npm-org-pkg.scss
@@ -1,5 +1,7 @@
 /* @import "~@org/pkg"; */
 @import "~@org/pkg";
+/* @import "~@org/bar/foo"; */
+@import "~@org/bar/foo";
 
 .foo {
     background: #000;

--- a/test/tools/createSpec.js
+++ b/test/tools/createSpec.js
@@ -15,6 +15,7 @@ function createSpec(ext) {
     const testNodeModules = path.relative(basePath, path.join(testFolder, "node_modules")) + path.sep;
     const pathToBootstrap = path.relative(basePath, path.resolve(testFolder, "..", "node_modules", "bootstrap-sass"));
     const pathToScopedNpmPkg = path.relative(basePath, path.resolve(testFolder, "node_modules", "@org", "pkg", "./index.scss"));
+    const pathToScopedNpmBarPkg = path.relative(basePath, path.resolve(testFolder, "node_modules", "@org", "bar"));
 
     fs.readdirSync(path.join(testFolder, ext))
         .filter((file) => {
@@ -32,6 +33,7 @@ function createSpec(ext) {
                         url = url
                             .replace(/^~bootstrap-sass/, pathToBootstrap)
                             .replace(/^~@org\/pkg/, pathToScopedNpmPkg)
+                            .replace(/^~@org\/bar/, pathToScopedNpmBarPkg)
                             .replace(/^~/, testNodeModules);
                     }
                     return {

--- a/test/tools/createSpec.js
+++ b/test/tools/createSpec.js
@@ -15,7 +15,6 @@ function createSpec(ext) {
     const testNodeModules = path.relative(basePath, path.join(testFolder, "node_modules")) + path.sep;
     const pathToBootstrap = path.relative(basePath, path.resolve(testFolder, "..", "node_modules", "bootstrap-sass"));
     const pathToScopedNpmPkg = path.relative(basePath, path.resolve(testFolder, "node_modules", "@org", "pkg", "./index.scss"));
-    const pathToScopedNpmBarPkg = path.relative(basePath, path.resolve(testFolder, "node_modules", "@org", "bar"));
 
     fs.readdirSync(path.join(testFolder, ext))
         .filter((file) => {
@@ -33,7 +32,6 @@ function createSpec(ext) {
                         url = url
                             .replace(/^~bootstrap-sass/, pathToBootstrap)
                             .replace(/^~@org\/pkg/, pathToScopedNpmPkg)
-                            .replace(/^~@org\/bar/, pathToScopedNpmBarPkg)
                             .replace(/^~/, testNodeModules);
                     }
                     return {


### PR DESCRIPTION
pr #447 introduce an issue with direct import from scoped npm packages, preventing sass-loader from formatting imported file correctly (see https://github.com/webpack-contrib/sass-loader/pull/447#issuecomment-300263537). This pr indented to fix the issue.