### PR TITLE
refactor: remove `this.cacheable`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -35,8 +35,6 @@ function sassLoader(content) {
         throw new Error("Synchronous compilation is not supported anymore. See https://github.com/webpack-contrib/sass-loader/issues/333");
     }
 
-    this.cacheable();
-
     const options = normalizeOptions(this, content, webpackImporter(
         resourcePath,
         pify(this.resolve.bind(this)),


### PR DESCRIPTION
Webpack 2 always cacheable all loaders by default.

Ref: https://github.com/webpack-contrib/sass-loader/blob/master/package.json#L36