### PR TITLE
add string support to importer param

### DIFF
--- a/lib/proxyCustomImporters.js
+++ b/lib/proxyCustomImporters.js
@@ -10,12 +10,18 @@
  *
  * We have to fix this behavior in order to provide a consistent experience to the webpack user.
  *
- * @param {function|Array<function>} importer
+ * @param {function|Array<function>|string} importer
  * @param {string} resourcePath
  * @returns {Array<function>}
  */
 function proxyCustomImporters(importer, resourcePath) {
     return [].concat(importer).map((importer) => {
+        if (typeof importer === 'string') {
+            try {
+                importer = require(importer);
+            } catch(e) {}
+        }
+
         return function (url, prev, done) {
             return importer.apply(
                 this, // eslint-disable-line no-invalid-this


### PR DESCRIPTION
Hi, let's make importer param available as string, mean importer === path to file with handler.
