### PR TITLE
chore(package): update `clone-deep` v0.3.1...2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "async": "^2.1.5",
-    "clone-deep": "^0.3.0",
+    "clone-deep": "^2.0.1",
     "loader-utils": "^1.0.1",
     "lodash.tail": "^4.1.1",
     "pify": "^3.0.0"


### PR DESCRIPTION
Just update `clone-deep` package to latest version. Seems don't have breaking changes.