### PR TITLE
feat: pass `loaderContext` to custom importer

### DIFF
--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -65,7 +65,7 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
     }
 
     // Allow passing custom importers to `node-sass`. Accepts `Function` or an array of `Function`s.
-    options.importer = options.importer ? proxyCustomImporters(options.importer, resourcePath) : [];
+    options.importer = options.importer ? proxyCustomImporters(options.importer, resourcePath, loaderContext) : [];
     options.importer.push(webpackImporter);
 
     // `node-sass` uses `includePaths` to resolve `@import` paths. Append the currently processed file.

--- a/lib/proxyCustomImporters.js
+++ b/lib/proxyCustomImporters.js
@@ -12,11 +12,15 @@
  *
  * @param {function|Array<function>} importer
  * @param {string} resourcePath
+ * @param {LoaderContext} loaderContext
  * @returns {Array<function>}
  */
-function proxyCustomImporters(importer, resourcePath) {
+function proxyCustomImporters(importer, resourcePath, loaderContext) {
     return [].concat(importer).map((importer) => {
         return function (url, prev, done) {
+            // eslint-disable-next-line no-invalid-this
+            this.loaderContext = loaderContext;
+
             return importer.apply(
                 this, // eslint-disable-line no-invalid-this
                 Array.from(arguments)


### PR DESCRIPTION
In some case i need use `addDependency` or `addContextDependency` (or other useful api stuff), be great have ability to this. If you accept this i will write tests for this, thank you!