### PR TITLE
[WIP] refactor(loader): v7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,11 @@ jobs:
   fast_finish: true
   allow_failures:
     - env: WEBPACK_VERSION=canary
+    - node_js: 9
   include:
     - &test-latest
       stage: Webpack latest
       node_js: 6
-      env: WEBPACK_VERSION=latest JOB_PART=test
-      script: npm run travis:$JOB_PART
-    - <<: *test-latest
-      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
@@ -30,6 +27,10 @@ jobs:
     - stage: Webpack canary
       node_js: 8
       env: WEBPACK_VERSION=4.0.0-alpha.0 JOB_PART=test
+      script: npm run travis:$JOB_PART
+    - stage: NodeJS Next
+      node_js: 9
+      env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
 before_install:
   - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 branches:
   only:
     - master
-    - feature/webpack3
 jobs:
   fast_finish: true
   allow_failures:
@@ -12,11 +11,11 @@ jobs:
   include:
     - &test-latest
       stage: Webpack latest
-      nodejs: 6
+      node_js: 6
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      nodejs: 4.8
+      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
@@ -29,10 +28,9 @@ jobs:
       script: npm run travis:$JOB_PART
       after_success: 'bash <(curl -s https://codecov.io/bash)'
     - stage: Webpack canary
-      before_script: npm i --no-save git://github.com/webpack/webpack.git#master
-      script: npm run travis:$JOB_PART
       node_js: 8
-      env: WEBPACK_VERSION=canary JOB_PART=test
+      env: WEBPACK_VERSION=4.0.0-alpha.0 JOB_PART=test
+      script: npm run travis:$JOB_PART
 before_install:
   - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'
   - nvm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,18 +11,18 @@ environment:
     - nodejs_version: '6'
       webpack_version: latest
       job_part: test
-    - nodejs_version: '4'
-      webpack_version: latest
+    - nodejs_version: '8'
+      webpack_version: 4.0.0-alpha.0
       job_part: test
 build: 'off'
 matrix:
   fast_finish: true
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm i -g npm@^5.0.0
+  - npm i -g npm@latest
   - npm install
 before_test:
-  - cmd: npm i --no-save webpack@%webpack_version%
+  - cmd: npm install webpack@%webpack_version%
 test_script:
   - node --version
   - npm --version

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "webpack-merge": "^4.0.0"
   },
   "engines": {
-    "node": ">= 4.3 < 5.0.0 || >= 5.10"
+    "node": ">= 6 || >= 8"
   },
   "peerDependencies": {
     "node-sass": "^4.0.0",
-    "webpack": "^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0"
+    "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
   },
   "keywords": [
     "sass",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-merge": "^4.0.0"
   },
   "engines": {
-    "node": ">= 6 || >= 8"
+    "node": ">= 6.9.0 || >= 8.9.0"
   },
   "peerDependencies": {
     "node-sass": "^4.0.0",


### PR DESCRIPTION
- Fixes for Webpack 4.x
- Drops support for NodeJS 4.x
- Sets minimum peerDep to Webpack 3.x

BREAKING CHANGE: Sets `engines` to `"node": ">= 6.9.0 || >= 8.9.0"`
BREAKING CHANGE: Drops support for Webpack `v2.x`