### PR TITLE
docs(README): rephrase `resolve-url-loader` note

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Since Sass/[libsass](https://github.com/sass/libsass) does not provide [url rewr
 
 More likely you will be disrupted by this second issue. It is natural to expect relative references to be resolved against the `.scss` file in which they are specified (like in regular `.css` files). Thankfully there are a two solutions to this problem:
 
-- Add the missing url rewriting using the [resolve-url-loader](https://github.com/bholloway/resolve-url-loader). Place it directly after the sass-loader in the loader chain.
+- Add the missing url rewriting using the [resolve-url-loader](https://github.com/bholloway/resolve-url-loader). Place it before the sass-loader in the loader chain.
 - Library authors usually provide a variable to modify the asset path. [bootstrap-sass](https://github.com/twbs/bootstrap-sass) for example has an `$icon-font-path`. Check out [this working bootstrap example](https://github.com/webpack-contrib/sass-loader/tree/master/test/bootstrapSass).
 
 ### Extracting style sheets


### PR DESCRIPTION
resolve-url-loader should be placed before the sass-loader . Otherwise it is not work for me!
webpack@3.10.0
webpack-dev-server@2.9.7
sass-loader@4.1.1
