### PR TITLE
docs(README): add example install instructions for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ as [`peerDependency`](https://docs.npmjs.com/files/package.json#peerdependencies
 
 Chain the sass-loader with the [css-loader](https://github.com/webpack-contrib/css-loader) and the [style-loader](https://github.com/webpack-contrib/style-loader) to immediately apply all styles to the DOM.
 
+```bash
+npm install style-loader css-loader --save-dev
+```
+
 ```js
 // webpack.config.js
 module.exports = {


### PR DESCRIPTION
When running the examples in the code an error is thrown that `style-loader` and `css-loader` are missing.