### PR TITLE
Report error to user for problems loading node-sass

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -29,7 +29,7 @@ function sassLoader(content) {
             sassVersion = /^(\d+)/.exec(require("node-sass/package.json").version).pop();
         } catch (e) {
             throw new Error(
-                "`sass-loader` requires `node-sass` >=4. Please install a compatible version."
+                "Error loading `node-sass`: " + e
             );
         }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -285,7 +285,7 @@ describe("sass-loader", () => {
             }, (err) => {
                 module._resolveFilename = originalResolve;
                 mockRequire.reRequire("node-sass");
-                err.message.should.match(/Please install a compatible version/);
+                err.message.should.match(/Error loading `node-sass`/);
                 done();
             });
         });


### PR DESCRIPTION
This addresses #561 

This provides the full error instead of:

 ``sass-loader` requires `node-sass` >=4. Please install a compatible version.``.

When I had the wrong node-sass binding for my version of Linux I get the following with this PR:

```
Module build failed: Error: Missing binding /node_modules/node-sass/vendor/linux-x64-51/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 7.x
```

Which directed me to the actual problem.