### PR TITLE
Add test cases to ensure that js files do not take precedence

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -205,7 +205,7 @@ describe("sass-loader", () => {
                     sourceMap.should.not.have.property("file");
                     sourceMap.should.have.property("sourceRoot", fakeCwd);
                     // This number needs to be updated if imports.scss or any dependency of that changes
-                    sourceMap.sources.should.have.length(10);
+                    sourceMap.sources.should.have.length(11);
                     sourceMap.sources.forEach(sourcePath =>
                         fs.existsSync(path.resolve(sourceMap.sourceRoot, sourcePath))
                     );

--- a/test/node_modules/another/module.js
+++ b/test/node_modules/another/module.js
@@ -1,0 +1,3 @@
+// node_modules/another/module.js: The sass-loader should not try to import that. scss, sass and css extensions should be preferred.
+// See https://github.com/webpack-contrib/sass-loader/issues/556#issuecomment-381154009
+"This should not be imported";

--- a/test/node_modules/another/module.scss
+++ b/test/node_modules/another/module.scss
@@ -1,0 +1,3 @@
+.another-scss-module-from-node-modules {
+  background: hotpink;
+}

--- a/test/scss/another/module.js
+++ b/test/scss/another/module.js
@@ -1,0 +1,3 @@
+// ./another/module.js: The sass-loader should not try to import that. scss, sass and css extensions should be preferred.
+// See https://github.com/webpack-contrib/sass-loader/issues/556#issuecomment-381154009
+"This should not be imported";

--- a/test/scss/imports.scss
+++ b/test/scss/imports.scss
@@ -1,8 +1,10 @@
 /* @import "another/module"; */
 @import "another/module";
+/* @import "~another/module"; */
+@import "~another/module";
 /* @import "another/underscore"; */
 @import "another/underscore";
-/* @import "another/underscore"; */
+/* @import "another/_underscore"; */
 @import "another/_underscore";
 /* @import "~scss/underscore"; */
 @import "~scss/underscore";


### PR DESCRIPTION
Additional test cases to ensure that `js` files do not take precedence over `scss` files when the webpack resolver is used. Based on https://github.com/webpack-contrib/sass-loader/pull/558