### PR TITLE
Add type guard to empty file check

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -63,6 +63,7 @@ function sassLoader(content) {
     ));
 
     // Skip empty files, otherwise it will stop webpack, see issue #21
+    // Guard against possibility of non-string data, see #569
     if (typeof options.data !== "string" || options.data.trim() === "") {
         callback(null, "");
         return;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -63,7 +63,7 @@ function sassLoader(content) {
     ));
 
     // Skip empty files, otherwise it will stop webpack, see issue #21
-    // Guard against possibility of non-string data, see #569
+    // Guard against possibility of non-string data, see PR #569
     if (typeof options.data !== "string" || options.data.trim() === "") {
         callback(null, "");
         return;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -63,7 +63,7 @@ function sassLoader(content) {
     ));
 
     // Skip empty files, otherwise it will stop webpack, see issue #21
-    if (options.data.trim() === "") {
+    if (typeof options.data !== 'string' || options.data.trim() === "") {
         callback(null, "");
         return;
     }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -63,7 +63,7 @@ function sassLoader(content) {
     ));
 
     // Skip empty files, otherwise it will stop webpack, see issue #21
-    if (typeof options.data !== 'string' || options.data.trim() === "") {
+    if (typeof options.data !== "string" || options.data.trim() === "") {
         callback(null, "");
         return;
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,6 +110,18 @@ syntaxStyles.forEach(ext => {
 });
 
 describe("sass-loader", () => {
+    it("should not throw errors when data is undefined", () => {
+        sassLoader.call(Object.assign({}, loaderContextMock, {
+            resourcePath: "",
+            query: {},
+            resolve() {
+                return null;
+            },
+            async() {
+                return () => null;
+            }
+        }), undefined);
+    });
     describe("multiple compilations", () => {
         it("should not interfere with each other", () =>
             new Promise((resolve, reject) => {


### PR DESCRIPTION
Getting an error when using with another loader that produces `options.data === undefined` under webpack4.