### PR TITLE
fix: Errors being swallowed when trying to load node-sass

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -21,17 +21,8 @@ let asyncSassJobQueue = null;
  */
 function sassLoader(content) {
     if (asyncSassJobQueue === null) {
-        let sass;
-        let sassVersion;
-
-        try {
-            sass = require("node-sass");
-            sassVersion = /^(\d+)/.exec(require("node-sass/package.json").version).pop();
-        } catch (e) {
-            throw new Error(
-                "Error loading `node-sass`: " + e
-            );
-        }
+        const sass = require("node-sass");
+        const sassVersion = /^(\d+)/.exec(require("node-sass/package.json").version).pop();
 
         if (Number(sassVersion) < 4) {
             throw new Error(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -266,7 +266,7 @@ describe("sass-loader", () => {
                 done();
             });
         });
-        it("should output a message when `node-sass` is missing", (done) => {
+        it("should not swallow errors when trying to load node-sass", (done) => {
             mockRequire.reRequire(pathToSassLoader);
             const module = require("module");
             const originalResolve = module._resolveFilename;
@@ -275,7 +275,7 @@ describe("sass-loader", () => {
                 if (!filename.match(/node-sass/)) {
                     return originalResolve.apply(this, arguments);
                 }
-                const err = new Error();
+                const err = new Error("Some error");
 
                 err.code = "MODULE_NOT_FOUND";
                 throw err;
@@ -285,7 +285,7 @@ describe("sass-loader", () => {
             }, (err) => {
                 module._resolveFilename = originalResolve;
                 mockRequire.reRequire("node-sass");
-                err.message.should.match(/Error loading `node-sass`/);
+                err.message.should.match(/Some error/);
                 done();
             });
         });


### PR DESCRIPTION
The current try/catch is not very helpful. I think it's more helpful to just let the error bubble up.

Fixes #563
Supersedes #575 