### PR TITLE
feat(importer): add support for custom file extensions (`options.extensions`)

### DIFF
--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -14,7 +14,7 @@ const matchModuleImport = /^~([^\/]+|@[^\/]+[\/][^\/]+)$/;
  * @param {string} url
  * @returns {Array<string>}
  */
-function importsToResolve(url) {
+function importsToResolve(url, extensions) {
     const request = utils.urlToRequest(url);
     // Keep in mind: ext can also be something like '.datepicker' when the true extension is omitted and the filename contains a dot.
     // @see https://github.com/webpack-contrib/sass-loader/issues/167
@@ -42,19 +42,20 @@ function importsToResolve(url) {
     const basename = path.basename(request);
 
     if (basename.charAt(0) === "_") {
-        return [
-            `${ request }.scss`, `${ request }.sass`, `${ request }.css`,
-            url
-        ];
+        const requests = extensions.map(ext => `${request}${ext}`)
+        request.push(url);
+
+        return requests;
     }
 
     const dirname = path.dirname(request);
+    const requests = []
+    
+    extensions.forEach(ext => requests.push(`${dirname}/_${basename}${ext}`));
+    extensions.forEach(ext => requests.push(`${request}${ext}`));
+    requests.push(url);
 
-    return [
-        `${ dirname }/_${ basename }.scss`, `${ dirname }/_${ basename }.sass`, `${ dirname }/_${ basename }.css`,
-        `${ request }.scss`, `${ request }.sass`, `${ request }.css`,
-        url
-    ];
+    return requests;
 }
 
 module.exports = importsToResolve;

--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -12,6 +12,7 @@ const matchModuleImport = /^~([^\/]+|@[^\/]+[\/][^\/]+)$/;
  * to enable straight-forward webpack.config aliases.
  *
  * @param {string} url
+ * @param {Array<string>} extensions
  * @returns {Array<string>}
  */
 function importsToResolve(url, extensions) {
@@ -42,20 +43,21 @@ function importsToResolve(url, extensions) {
     const basename = path.basename(request);
 
     if (basename.charAt(0) === "_") {
-        const requests = extensions.map(ext => `${request}${ext}`)
-        request.push(url);
+        const paths = extensions.map(ext => `${ request }${ ext }`) || [];
 
-        return requests;
+        paths.push(url);
+
+        return paths;
     }
 
     const dirname = path.dirname(request);
-    const requests = []
-    
-    extensions.forEach(ext => requests.push(`${dirname}/_${basename}${ext}`));
-    extensions.forEach(ext => requests.push(`${request}${ext}`));
-    requests.push(url);
+    const paths = [];
 
-    return requests;
+    extensions.forEach(ext => paths.push(`${ dirname }/_${ basename }${ ext }`));
+    extensions.forEach(ext => paths.push(`${ request }${ ext }`));
+    paths.push(url);
+
+    return paths;
 }
 
 module.exports = importsToResolve;

--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -64,7 +64,7 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
         options.indentedSyntax = Boolean(options.indentedSyntax);
     }
 
-    // Configure the file extensions the importer will search for...
+    // Configure extensions the importer will use for resolving files...
     options.extensions = options.extensions || [".scss", ".sass", ".css"];
 
     // Allow passing custom importers to `node-sass`. Accepts `Function` or an array of `Function`s.

--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -75,8 +75,6 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
     options.includePaths = options.includePaths || [];
     options.includePaths.push(path.dirname(resourcePath));
 
-
-
     return options;
 }
 

--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -64,13 +64,18 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
         options.indentedSyntax = Boolean(options.indentedSyntax);
     }
 
+    // Configure the file extensions the importer will search for...
+    options.extensions = options.extensions || [".scss", ".sass", ".css"];
+
     // Allow passing custom importers to `node-sass`. Accepts `Function` or an array of `Function`s.
     options.importer = options.importer ? proxyCustomImporters(options.importer, resourcePath) : [];
-    options.importer.push(webpackImporter);
+    options.importer.push(webpackImporter(options.extensions));
 
     // `node-sass` uses `includePaths` to resolve `@import` paths. Append the currently processed file.
     options.includePaths = options.includePaths || [];
     options.includePaths.push(path.dirname(resourcePath));
+
+
 
     return options;
 }

--- a/lib/webpackImporter.js
+++ b/lib/webpackImporter.js
@@ -59,14 +59,15 @@ function webpackImporter(resourcePath, resolve, addNormalizedDependency) {
                 ));
     }
 
-    return (url, prev, done) => {
-        startResolving(
-            dirContextFrom(prev),
-            importsToResolve(url)
-        ) // Catch all resolving errors, return the original file and pass responsibility back to other custom importers
-            .catch(() => ({ file: url }))
-            .then(done);
-    };
+    return (extensions) =>
+        (url, prev, done) => {
+            startResolving(
+                dirContextFrom(prev),
+                importsToResolve(url, extensions)
+            ) // Catch all resolving errors, return the original file and pass responsibility back to other custom importers
+                .catch(() => ({ file: url }))
+                .then(done);
+        };
 }
 
 module.exports = webpackImporter;


### PR DESCRIPTION
We are looking to add custom extensions support. Enabling files to be swapped out at compile time.

The following example allows shows the how the extensions would be configured.

```js
{
  loader: "sass-loader",
    options: {
      sourceMap: true,
      extensions: [`.myext.scss`, ".scss", ".sass", ".css"],
    }
}
```

In our use case, we supply an arg to webpack-cli that configures the custom extension we wish to build. 

Would you be interested in adding this to sass-loader as a feature.


