### PR TITLE
Remove reference to node-sass as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Looking for the webpack 1 loader? Check out the [archive/webpack-1 branch](https
 npm install sass-loader node-sass webpack --save-dev
 ```
 
-The sass-loader requires [node-sass](https://github.com/sass/node-sass) and [webpack](https://github.com/webpack)
-as [`peerDependency`](https://docs.npmjs.com/files/package.json#peerdependencies). Thus you are able to control the versions accurately.
+The sass-loader requires [[webpack](https://github.com/webpack)
+as [`peerDependency`](https://docs.npmjs.com/files/package.json#peerdependencies). Thus you are able to control the version accurately.
 
 <h2 align="center">Examples</h2>
 


### PR DESCRIPTION
Per https://github.com/webpack-contrib/sass-loader/pull/533, `node-sass` is no longer a `peerDependency`, this updates the README to reflect that.