### PR TITLE
docs(readme): Adding extract-css-chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ There are two possibilities to extract a style sheet from the bundle:
 
 - [extract-loader](https://github.com/peerigon/extract-loader) (simpler, but specialized on the css-loader's output)
 - [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) (use this, when using webpack 4 configuration. Works in all use-cases)
+- [extract-css-chunks-webpack-plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin) (hot module reload friendly extended version of mini-css-extract-plugin. HMR real CSS files in dev, works like mini-css in non-dev)
 
 ### Source maps
 


### PR DESCRIPTION
Adding another option to the readme, it’s mini-css with some built-in capabilities to support hot module reloading of css files in development.

It’s super fast and more debuggable than having to use style-loader to append massive amounts of css. 

It would be a great addition for users looking to have dev mimic production closely, it should help cascading collisions and general performance in the browser as the dom won’t have huge css written into its head.