### PR TITLE
test: support import index file from package

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -171,6 +171,11 @@ implementations.forEach((implementation) => {
             ));
           it('should resolve sass field correctly', () =>
             execTest(`import-sass-field`));
+          // Works only in dart-sass implementation
+          if (implementation === dartSass) {
+            it('should resolve index file in module correctly', () =>
+              execTest('import-index'));
+          }
         });
         describe('custom importers', () => {
           it('should use custom importer', () =>

--- a/test/node_modules/sass-package-with-index/index.sass
+++ b/test/node_modules/sass-package-with-index/index.sass
@@ -1,0 +1,2 @@
+a
+  color: red

--- a/test/node_modules/scss-package-with-index/index.scss
+++ b/test/node_modules/scss-package-with-index/index.scss
@@ -1,0 +1,3 @@
+a {
+  color: red;
+}

--- a/test/sass/import-index.sass
+++ b/test/sass/import-index.sass
@@ -1,0 +1,1 @@
+@import "~sass-package-with-index"

--- a/test/scss/import-index.scss
+++ b/test/scss/import-index.scss
@@ -1,0 +1,1 @@
+@import "~scss-package-with-index";

--- a/test/tools/createSpec.js
+++ b/test/tools/createSpec.js
@@ -113,6 +113,13 @@ function createSpec(ext) {
           return;
         }
 
+        if (fileWithoutExt === 'import-index' && implementation !== dartSass) {
+          // Skip CSS imports for all implementations that are not node-sass
+          // CSS imports is a legacy feature that we only support for node-sass
+          // See discussion https://github.com/webpack-contrib/sass-loader/pull/573/files?#r199109203
+          return;
+        }
+
         sassOptions.functions = customFunctions(implementation);
 
         const [name] = implementation.info.split('\t');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Ensure we support import from package where `index.scss` present.

fixes #535

### Breaking Changes

No

### Additional Info

Looks we already support this since `7` version, just add tests