### PR TITLE
Allow passing `functions` option as function

### DIFF
--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -23,6 +23,11 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
   const options = cloneDeep(utils.getOptions(loaderContext)) || {};
   const { resourcePath } = loaderContext;
 
+  // allow opt.functions to be configured WRT loaderContext
+  if (typeof options.functions === 'function') {
+    options.functions = options.functions(loaderContext);
+  }
+
   let { data } = options;
 
   if (typeof options.data === 'function') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -190,6 +190,13 @@ implementations.forEach((implementation) => {
             execTest('custom-functions', {
               functions: customFunctions(implementation),
             }));
+          it('should expose custom functions if the option is a function', () =>
+            execTest('custom-functions', {
+              functions: (loaderContext) => {
+                should.exist(loaderContext);
+                return customFunctions(implementation);
+              },
+            }));
         });
         describe('prepending data', () => {
           it('should extend the data option if present and it is string', () =>


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This PR adds support for supplying the `functions` option as a function of the [Loader Context](https://webpack.js.org/api/loaders/#the-loader-context). This corresponds to part of [the issue I filed here](https://github.com/webpack-contrib/sass-loader/issues/650).

### Breaking Changes

None. Added a test similar to the one for the "`data` as function"; it passes.
