### PR TITLE
fix: import files directly from scoped npm package

### DIFF
--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -5,6 +5,7 @@ const path = require('path');
 const utils = require('loader-utils');
 
 const matchModuleImport = /^~([^/]+|@[^/]+[/][^/]+)$/;
+const matchScopedNpmPackage = /^@.*\//;
 
 /**
  * When libsass tries to resolve an import, it uses a special algorithm.
@@ -23,6 +24,13 @@ function importsToResolve(url) {
 
   if (matchModuleImport.test(url)) {
     return [request, url];
+  }
+
+  // In case there is a deep import from a scoped NPM package
+  // ex: @import '@component-lib/button'
+  // return nothing and let node-sass handle the import directly
+  if (matchScopedNpmPackage.test(url)) {
+    return [];
   }
 
   // libsass' import algorithm works like this:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -154,6 +154,10 @@ implementations.forEach((implementation) => {
             execTest('bootstrap-sass'));
           it('should correctly import scoped npm packages', () =>
             execTest('import-from-npm-org-pkg'));
+          it('should directly import scoped npm packages', () =>
+            execTest('import-directly-from-npm-org-pkg', {
+              includePaths: [path.join(__dirname, 'node_modules')],
+            }));
           it('should resolve aliases', () =>
             execTest(
               'import-alias',

--- a/test/node_modules/@org/baz/qux.scss
+++ b/test/node_modules/@org/baz/qux.scss
@@ -1,0 +1,3 @@
+.scoped-npm-pkg-qux {
+  background: purple;
+}

--- a/test/sass/import-directly-from-npm-org-pkg.sass
+++ b/test/sass/import-directly-from-npm-org-pkg.sass
@@ -1,0 +1,5 @@
+/* @import ~@org/pkg */
+@import @org/baz/qux
+
+.foo
+    background: #000

--- a/test/scss/import-directly-from-npm-org-pkg.scss
+++ b/test/scss/import-directly-from-npm-org-pkg.scss
@@ -1,0 +1,6 @@
+/* @import "~@org/pkg"; */
+@import "@org/baz/qux";
+
+.foo {
+    background: #000;
+}

--- a/test/tools/createSpec.js
+++ b/test/tools/createSpec.js
@@ -18,6 +18,10 @@ function createSpec(ext) {
   const basePath = path.join(testFolder, ext);
   const testNodeModules =
     path.relative(basePath, path.join(testFolder, 'node_modules')) + path.sep;
+  const testDirectNodeModules = path.relative(
+    basePath,
+    path.join(testFolder, 'node_modules', '@')
+  );
   const pathToBootstrap = path.relative(
     basePath,
     path.resolve(testFolder, '..', 'node_modules', 'bootstrap-sass')
@@ -84,6 +88,7 @@ function createSpec(ext) {
               .replace(/^~module/, pathToModule)
               .replace(/^~another/, pathToAnother)
               .replace(/^~/, testNodeModules)
+              .replace(/^@/, testDirectNodeModules)
               .replace(/^path-to-alias/, pathToFooAlias);
           }
           return {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When a scoped NPM package import is encountered, sass-loader will prepare a handful of file variations to import. This results in several checks to import files that do not exist, which considerably hampers expected performance. This can be partially avoided by prefixing NPM packages with `~`; however, when this is done inside of external packages, it is not something that can be controlled. 

This is primarily driven by our use of https://github.com/material-components/material-components-web, which makes extensive use of cross-package imports. ex: https://github.com/material-components/material-components-web/blob/master/packages/mdc-textfield/mdc-text-field.scss#L23-L32

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This change may effect projects where import paths follow the scoped module naming conventions `@import @someNestedFolder/sassFile`, where those import paths do not reside in `node_modules`. If these are local imports, this issue may be resolved by prepending `./` to ensure the import is handled relative to the requesting file. 

### Additional Info

Scoped NPM imports do still work without this change, but look-ups are not optimized for the scenario. This can result in hundreds of imports (depending on project) looking for ~6 non-existent files. 