### PR TITLE
Use the index of stdin instead of zero

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -86,9 +86,12 @@ function sassLoader(content) {
       // Since we specified options.sourceMap = path.join(process.cwd(), "/sass.map"); in normalizeOptions,
       // we know that this path is relative to process.cwd(). This is how node-sass works.
       // eslint-disable-next-line no-param-reassign
-      let stdinIndex = result.map.sources.indexOf("stdin");
+      let stdinIndex = result.map.sources.indexOf('stdin');
       stdinIndex = stdinIndex !== -1 ? stdinIndex : 0;
-      result.map.sources[stdinIndex] = path.relative(process.cwd(), resourcePath);
+      result.map.sources[stdinIndex] = path.relative(
+        process.cwd(),
+        resourcePath
+      );
       // node-sass returns POSIX paths, that's why we need to transform them back to native paths.
       // This fixes an error on windows where the source-map module cannot resolve the source maps.
       // @see https://github.com/webpack-contrib/sass-loader/issues/366#issuecomment-279460722

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -86,7 +86,9 @@ function sassLoader(content) {
       // Since we specified options.sourceMap = path.join(process.cwd(), "/sass.map"); in normalizeOptions,
       // we know that this path is relative to process.cwd(). This is how node-sass works.
       // eslint-disable-next-line no-param-reassign
-      result.map.sources[0] = path.relative(process.cwd(), resourcePath);
+      let stdinIndex = result.map.sources.indexOf("stdin");
+      stdinIndex = stdinIndex !== -1 ? stdinIndex : 0;
+      result.map.sources[stdinIndex] = path.relative(process.cwd(), resourcePath);
       // node-sass returns POSIX paths, that's why we need to transform them back to native paths.
       // This fixes an error on windows where the source-map module cannot resolve the source maps.
       // @see https://github.com/webpack-contrib/sass-loader/issues/366#issuecomment-279460722

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -81,19 +81,21 @@ function sassLoader(content) {
       // Since we don't know the final filename in the webpack build chain yet, it makes no sense to have it.
       // eslint-disable-next-line no-param-reassign
       delete result.map.file;
-      // The first source is 'stdin' according to node-sass because we've used the data input.
+      // One of the sources is 'stdin' according to dart-sass/node-sass because we've used the data input.
       // Now let's override that value with the correct relative path.
       // Since we specified options.sourceMap = path.join(process.cwd(), "/sass.map"); in normalizeOptions,
       // we know that this path is relative to process.cwd(). This is how node-sass works.
       // eslint-disable-next-line no-param-reassign
-      let stdinIndex = result.map.sources.findIndex(
+      const stdinIndex = result.map.sources.findIndex(
         (source) => source.indexOf('stdin') !== -1
       );
-      stdinIndex = stdinIndex !== -1 ? stdinIndex : 0;
-      result.map.sources[stdinIndex] = path.relative(
-        process.cwd(),
-        resourcePath
-      );
+
+      if (stdinIndex !== -1) {
+        result.map.sources[stdinIndex] = path.relative(
+          process.cwd(),
+          resourcePath
+        );
+      }
       // node-sass returns POSIX paths, that's why we need to transform them back to native paths.
       // This fixes an error on windows where the source-map module cannot resolve the source maps.
       // @see https://github.com/webpack-contrib/sass-loader/issues/366#issuecomment-279460722

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -86,7 +86,9 @@ function sassLoader(content) {
       // Since we specified options.sourceMap = path.join(process.cwd(), "/sass.map"); in normalizeOptions,
       // we know that this path is relative to process.cwd(). This is how node-sass works.
       // eslint-disable-next-line no-param-reassign
-      let stdinIndex = result.map.sources.indexOf('stdin');
+      let stdinIndex = result.map.sources.findIndex(
+        (source) => source.indexOf('stdin') !== -1
+      );
       stdinIndex = stdinIndex !== -1 ? stdinIndex : 0;
       result.map.sources[stdinIndex] = path.relative(
         process.cwd(),


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Solves issue #671, which breaks the use of resolve-url-loader

### Breaking Changes

None

### Additional Info

This will look for "stdin" in the list of sources and replace it with the Sass file. If it can't find the string for whatever reason, it will ~~fall back to the previous functionality and just use the 0th index~~ not do anything.

fixes #671