### PR TITLE
feat: add loading index file when loading directory

### DIFF
--- a/lib/importsToResolve.js
+++ b/lib/importsToResolve.js
@@ -55,6 +55,9 @@ function importsToResolve(url) {
     `${request}.scss`,
     `${request}.sass`,
     `${request}.css`,
+    `${request}/_index.sass`,
+    `${request}/_index.scss`,
+    `${request}/_index.css`,
     url,
   ];
 }


### PR DESCRIPTION
This PR contains a:


This PR provides load folders in Sass. If you write _index.scss or _index.sass or _index.css in a folder, then when you import the folder itself, this file will be loaded into its place.

opportunity taken from [import index files](https://sass-lang.com/documentation/at-rules/import)

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

you can use:
`@import workspace/src/sass/someDir`

instead it:
`@import workspace/src/sass/someDir/_index.sass`

### Breaking Changes

Not a breaking change

### Additional Info
