### PR TITLE
fix: use "compressed" output when mode is "production"

### DIFF
--- a/src/getSassOptions.js
+++ b/src/getSassOptions.js
@@ -5,6 +5,14 @@ import cloneDeep from 'clone-deep';
 
 import proxyCustomImporters from './proxyCustomImporters';
 
+function isProductionLikeMode(loaderContext) {
+  return (
+    loaderContext.mode === 'production' ||
+    !loaderContext.mode ||
+    loaderContext.minimize
+  );
+}
+
 /**
  * Derives the sass options from the loader context and normalizes its values with sane defaults.
  *
@@ -34,7 +42,7 @@ function getSassOptions(loaderContext, loaderOptions, content) {
   options.data = data ? data + os.EOL + content : content;
 
   // opt.outputStyle
-  if (!options.outputStyle && loaderContext.minimize) {
+  if (!options.outputStyle && isProductionLikeMode(loaderContext)) {
     options.outputStyle = 'compressed';
   }
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -282,6 +282,22 @@ exports[`loader should work and ignore all css "@import" at-rules (node-sass) (s
 
 exports[`loader should work and ignore all css "@import" at-rules (node-sass) (scss): warnings 1`] = `Array []`;
 
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`loader should work and output the "compressed" outputStyle when "mode" is production (node-sass) (scss): warnings 1`] = `Array []`;
+
 exports[`loader should work and use the "_index" file in package (dart-sass) (sass): errors 1`] = `Array []`;
 
 exports[`loader should work and use the "_index" file in package (dart-sass) (sass): warnings 1`] = `Array []`;

--- a/test/helpers/compiler.js
+++ b/test/helpers/compiler.js
@@ -55,6 +55,7 @@ export default function(fixture, config = {}, options = {}) {
     plugins: plugins(config),
     optimization: {
       runtimeChunk: false,
+      minimizer: [],
     },
     // eslint-disable-next-line no-undefined
     resolve: config.resolve || undefined,

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -525,6 +525,29 @@ describe('loader', () => {
         expect(stats.compilation.warnings).toMatchSnapshot('warnings');
         expect(stats.compilation.errors).toMatchSnapshot('errors');
       });
+
+      it(`should work and output the "compressed" outputStyle when "mode" is production (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+        };
+        const stats = await compile(testId, {
+          mode: 'production',
+          loader: { options },
+        });
+
+        expect(getCode(stats).content).toBe(
+          getPureCode(
+            testId,
+            Object.assign({}, options, {
+              outputStyle: 'compressed',
+            })
+          )
+        );
+
+        expect(stats.compilation.warnings).toMatchSnapshot('warnings');
+        expect(stats.compilation.errors).toMatchSnapshot('errors');
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This bug was introduced when we migrate on webpack@4, works fine for webpack@3

### Breaking Changes

No

### Additional Info

No