### PR TITLE
refactor: the `data` option was renamed to the `prependData` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ Thankfully there are a two solutions to this problem:
 By default all options passed to loader also passed to to [Node Sass](https://github.com/sass/node-sass) or [Dart Sass](http://sass-lang.com/dart-sass)
 
 > ℹ️ The `indentedSyntax` option has `true` value for the `sass` extension.
+
 > ℹ️ Options such as `file` and `outFile` are unavailable.
+
 > ℹ️ Only the "expanded" and "compressed" values of outputStyle are supported for `dart-sass`.
+
 > ℹ We recommend don't use `sourceMapContents`, `sourceMapEmbed`, `sourceMapRoot` options because loader automatically setup this options.
 
 There is a slight difference between the `node-sass` and `sass` options. We recommend look documentation before used them:
@@ -236,7 +239,7 @@ module.exports = {
 };
 ```
 
-### `data`
+### `prependData`
 
 Type: `String|Function`
 Default: `undefined`
@@ -262,7 +265,7 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
-              data: '$env: ' + process.env.NODE_ENV + ';',
+              prependData: '$env: ' + process.env.NODE_ENV + ';',
             },
           },
         ],
@@ -286,8 +289,8 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
-              data: (loaderContext) => {
-                // More information about avalaible options https://webpack.js.org/api/loaders/
+              prependData: (loaderContext) => {
+                // More information about available properties https://webpack.js.org/api/loaders/
                 const { resourcePath, rootContext } = loaderContext;
                 const relativePath = path.relative(rootContext, resourcePath);
 

--- a/src/getSassOptions.js
+++ b/src/getSassOptions.js
@@ -33,13 +33,13 @@ function getSassOptions(loaderContext, loaderOptions, content) {
     options.functions = options.functions(loaderContext);
   }
 
-  let { data } = options;
+  let { prependData } = options;
 
-  if (typeof options.data === 'function') {
-    data = options.data(loaderContext);
+  if (typeof prependData === 'function') {
+    prependData = prependData(loaderContext);
   }
 
-  options.data = data ? data + os.EOL + content : content;
+  options.data = prependData ? prependData + os.EOL + content : content;
 
   // opt.outputStyle
   if (!options.outputStyle && isProductionLikeMode(loaderContext)) {

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -658,38 +658,6 @@ exports[`loader should work with the "bootstrap-sass" package, import as a packa
 
 exports[`loader should work with the "bootstrap-sass" package, import as a package (node-sass) (scss): warnings 1`] = `Array []`;
 
-exports[`loader should work with the "data" option as a function (dart-sass) (sass): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (dart-sass) (sass): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (dart-sass) (scss): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (dart-sass) (scss): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (node-sass) (sass): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (node-sass) (sass): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (node-sass) (scss): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a function (node-sass) (scss): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (dart-sass) (sass): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (dart-sass) (sass): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (dart-sass) (scss): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (dart-sass) (scss): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (node-sass) (sass): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (node-sass) (sass): warnings 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (node-sass) (scss): errors 1`] = `Array []`;
-
-exports[`loader should work with the "data" option as a string (node-sass) (scss): warnings 1`] = `Array []`;
-
 exports[`loader should work with the "functions" option as a function (dart-sass) (sass): errors 1`] = `Array []`;
 
 exports[`loader should work with the "functions" option as a function (dart-sass) (sass): warnings 1`] = `Array []`;

--- a/test/__snapshots__/prependData-option.test.js.snap
+++ b/test/__snapshots__/prependData-option.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prependData option should work with the "data" option as a function (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a function (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`prependData option should work with the "data" option as a string (node-sass) (scss): warnings 1`] = `Array []`;

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -14,7 +14,7 @@ function getCodeFromSass(testId, options) {
 
   const isSass = /\.sass$/i.test(testId);
 
-  if (sassOptions.data) {
+  if (sassOptions.prependData) {
     sassOptions.indentedSyntax = isSass;
     sassOptions.data = `$prepended-data: hotpink${
       sassOptions.indentedSyntax ? '\n' : ';'

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -109,42 +109,6 @@ describe('loader', () => {
         expect(stats.compilation.errors).toMatchSnapshot('errors');
       });
 
-      it(`should work with the "data" option as a string (${implementationName}) (${syntax})`, async () => {
-        const testId = getTestId('prepending-data', syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          data: `$prepended-data: hotpink${syntax === 'sass' ? '\n' : ';'}`,
-        };
-        const stats = await compile(testId, { loader: { options } });
-
-        expect(getCodeFromBundle(stats).css).toBe(
-          getCodeFromSass(testId, options).css
-        );
-
-        expect(stats.compilation.warnings).toMatchSnapshot('warnings');
-        expect(stats.compilation.errors).toMatchSnapshot('errors');
-      });
-
-      it(`should work with the "data" option as a function (${implementationName}) (${syntax})`, async () => {
-        const testId = getTestId('prepending-data', syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          data: (loaderContext) => {
-            expect(loaderContext).toBeDefined();
-
-            return `$prepended-data: hotpink${syntax === 'sass' ? '\n' : ';'}`;
-          },
-        };
-        const stats = await compile(testId, { loader: { options } });
-
-        expect(getCodeFromBundle(stats).css).toBe(
-          getCodeFromSass(testId, options).css
-        );
-
-        expect(stats.compilation.warnings).toMatchSnapshot('warnings');
-        expect(stats.compilation.errors).toMatchSnapshot('errors');
-      });
-
       it(`should work with the "includePaths" option (${implementationName}) (${syntax})`, async () => {
         const testId = getTestId('import-include-paths', syntax);
         const options = {

--- a/test/prependData-option.test.js
+++ b/test/prependData-option.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+import nodeSass from 'node-sass';
+import dartSass from 'sass';
+
+import {
+  compile,
+  getTestId,
+  getCodeFromBundle,
+  getCodeFromSass,
+  getImplementationByName,
+} from './helpers';
+
+const implementations = [nodeSass, dartSass];
+const syntaxStyles = ['scss', 'sass'];
+
+describe('prependData option', () => {
+  implementations.forEach((implementation) => {
+    const [implementationName] = implementation.info.split('\t');
+
+    syntaxStyles.forEach((syntax) => {
+      it(`should work with the "data" option as a string (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('prepending-data', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          prependData: `$prepended-data: hotpink${
+            syntax === 'sass' ? '\n' : ';'
+          }`,
+        };
+        const stats = await compile(testId, { loader: { options } });
+
+        expect(getCodeFromBundle(stats).css).toBe(
+          getCodeFromSass(testId, options).css
+        );
+
+        expect(stats.compilation.warnings).toMatchSnapshot('warnings');
+        expect(stats.compilation.errors).toMatchSnapshot('errors');
+      });
+
+      it(`should work with the "data" option as a function (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('prepending-data', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          prependData: (loaderContext) => {
+            expect(loaderContext).toBeDefined();
+
+            return `$prepended-data: hotpink${syntax === 'sass' ? '\n' : ';'}`;
+          },
+        };
+        const stats = await compile(testId, { loader: { options } });
+
+        expect(getCodeFromBundle(stats).css).toBe(
+          getCodeFromSass(testId, options).css
+        );
+
+        expect(stats.compilation.warnings).toMatchSnapshot('warnings');
+        expect(stats.compilation.errors).toMatchSnapshot('errors');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Avoid misleading between `data` option for `sass` and prepend data option for `sass-loader`

### Breaking Changes

BREAKING CHANGE: the `data` option was renamed to the `prependData` option

### Additional Info

No