### PR TITLE
refactor: code

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ Options for [Dart Sass](http://sass-lang.com/dart-sass) or [Node Sass](https://g
 
 > ℹ️ The `indentedSyntax` option has `true` value for the `sass` extension.
 
-> ℹ️ Options such as `file` and `outFile` are unavailable.
+> ℹ️ Options such as `data` and `file` are unavailable and will be ignored.
 
-> ℹ We recommend not to use the `sourceMapContents`, `sourceMapEmbed`, `sourceMapRoot` options because `sass-loader` automatically sets these options.
+> ℹ We recommend not to set the `outFile`, `sourceMapContents`, `sourceMapEmbed`, `sourceMapRoot` options because `sass-loader` automatically sets these options when the `sourceMap` option is `true`.
 
 There is a slight difference between the `sass` (`dart-sass`) and `node-sass` options.
 
@@ -411,7 +411,10 @@ Default: depends on the `compiler.devtool` value
 
 Enables/Disables generation of source maps.
 
-By default generation of source maps depends on the [`devtool`](https://webpack.js.org/configuration/devtool/) option. All values enable source map generation except `eval` and `false` value.
+By default generation of source maps depends on the [`devtool`](https://webpack.js.org/configuration/devtool/) option.
+All values enable source map generation except `eval` and `false` value.
+
+> ℹ If a `true` the `sourceMap`, `sourceMapRoot`, `sourceMapEmbed`, `sourceMapContents` and `omitSourceMapUrl` from `sassOptions` will be ignored.
 
 **webpack.config.js**
 

--- a/src/getSassOptions.js
+++ b/src/getSassOptions.js
@@ -74,9 +74,6 @@ function getSassOptions(loaderContext, loaderOptions, content, implementation) {
       ? loaderOptions.sourceMap
       : loaderContext.sourceMap;
 
-  // opt.sourceMap
-  // Not using the `this.sourceMap` flag because css source maps are different
-  // @see https://github.com/webpack/css-loader/pull/40
   if (useSourceMap) {
     // Deliberately overriding the sourceMap option here.
     // node-sass won't produce source maps if the data option is used and options.sourceMap is not a string.
@@ -85,22 +82,10 @@ function getSassOptions(loaderContext, loaderOptions, content, implementation) {
     // all paths in sourceMap.sources will be relative to that path.
     // Pretty complicated... :(
     options.sourceMap = path.join(process.cwd(), '/sass.map');
-
-    if ('sourceMapRoot' in options === false) {
-      options.sourceMapRoot = process.cwd();
-    }
-
-    if ('omitSourceMapUrl' in options === false) {
-      // The source map url doesn't make sense because we don't know the output path
-      // The css-loader will handle that for us
-      options.omitSourceMapUrl = true;
-    }
-
-    if ('sourceMapContents' in options === false) {
-      // If sourceMapContents option is not set, set it to true otherwise maps will be empty/null
-      // when exported by webpack-extract-text-plugin.
-      options.sourceMapContents = true;
-    }
+    options.sourceMapRoot = process.cwd();
+    options.sourceMapContents = true;
+    options.omitSourceMapUrl = true;
+    options.sourceMapEmbed = false;
   }
 
   const { resourcePath } = loaderContext;
@@ -110,7 +95,7 @@ function getSassOptions(loaderContext, loaderOptions, content, implementation) {
   if (
     ext &&
     ext.toLowerCase() === '.sass' &&
-    'indentedSyntax' in options === false
+    typeof options.indentedSyntax === 'undefined'
   ) {
     options.indentedSyntax = true;
   } else {

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -188,6 +188,382 @@ exports[`sassOptions option should don't use the "fibers" package when the "fibe
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (scss): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.message, .success, .error, .warning {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  border-color: green; }
+
+.error {
+  border-color: red; }
+
+.warning {
+  border-color: yellow; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.message, .success, .error, .warning {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  border-color: green; }
+
+.error {
+  border-color: red; }
+
+.warning {
+  border-color: yellow; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option (node-sass) (scss): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (sass): css 1`] = `
 "@charset \\"UTF-8\\";
 body {
@@ -1433,3 +1809,755 @@ exports[`sassOptions option should work with the "includePaths" option (node-sas
 exports[`sassOptions option should work with the "includePaths" option (node-sass) (scss): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "includePaths" option (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+		font: 100% Helvetica, sans-serif;
+		color: #333;
+}
+
+nav ul {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+}
+nav li {
+		display: inline-block;
+}
+nav a {
+		display: block;
+		padding: 6px 12px;
+		text-decoration: none;
+}
+
+.box {
+		-webkit-border-radius: 10px;
+		-moz-border-radius: 10px;
+		-ms-border-radius: 10px;
+		border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+		border: 1px solid #ccc;
+		padding: 10px;
+		color: #333;
+}
+
+.success {
+		border-color: green;
+}
+
+.error {
+		border-color: red;
+}
+
+.warning {
+		border-color: yellow;
+}
+
+.foo:before {
+		content: \\"\\";
+}
+
+.bar:before {
+		content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+		font: 100% Helvetica, sans-serif;
+		color: #333;
+}
+
+nav ul {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+}
+nav li {
+		display: inline-block;
+}
+nav a {
+		display: block;
+		padding: 6px 12px;
+		text-decoration: none;
+}
+
+.box {
+		-webkit-border-radius: 10px;
+		-moz-border-radius: 10px;
+		-ms-border-radius: 10px;
+		border-radius: 10px;
+}
+
+.foo:before {
+		content: \\"\\";
+}
+
+.bar:before {
+		content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+		font: 100% Helvetica, sans-serif;
+		color: #333; }
+
+nav ul {
+		margin: 0;
+		padding: 0;
+		list-style: none; }
+
+nav li {
+		display: inline-block; }
+
+nav a {
+		display: block;
+		padding: 6px 12px;
+		text-decoration: none; }
+
+.box {
+		-webkit-border-radius: 10px;
+		-moz-border-radius: 10px;
+		-ms-border-radius: 10px;
+		border-radius: 10px; }
+
+.message, .success, .error, .warning {
+		border: 1px solid #ccc;
+		padding: 10px;
+		color: #333; }
+
+.success {
+		border-color: green; }
+
+.error {
+		border-color: red; }
+
+.warning {
+		border-color: yellow; }
+
+.foo:before {
+		content: \\"\\"; }
+
+.bar:before {
+		content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+		font: 100% Helvetica, sans-serif;
+		color: #333; }
+
+nav ul {
+		margin: 0;
+		padding: 0;
+		list-style: none; }
+
+nav li {
+		display: inline-block; }
+
+nav a {
+		display: block;
+		padding: 6px 12px;
+		text-decoration: none; }
+
+.box {
+		-webkit-border-radius: 10px;
+		-moz-border-radius: 10px;
+		-ms-border-radius: 10px;
+		border-radius: 10px; }
+
+.foo:before {
+		content: \\"\\"; }
+
+.bar:before {
+		content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+    font: 100% Helvetica, sans-serif;
+    color: #333;
+}
+
+nav ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+nav li {
+    display: inline-block;
+}
+nav a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+}
+
+.box {
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+    border: 1px solid #ccc;
+    padding: 10px;
+    color: #333;
+}
+
+.success {
+    border-color: green;
+}
+
+.error {
+    border-color: red;
+}
+
+.warning {
+    border-color: yellow;
+}
+
+.foo:before {
+    content: \\"\\";
+}
+
+.bar:before {
+    content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+    font: 100% Helvetica, sans-serif;
+    color: #333;
+}
+
+nav ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+nav li {
+    display: inline-block;
+}
+nav a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+}
+
+.box {
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px;
+}
+
+.foo:before {
+    content: \\"\\";
+}
+
+.bar:before {
+    content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+    font: 100% Helvetica, sans-serif;
+    color: #333; }
+
+nav ul {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+
+nav li {
+    display: inline-block; }
+
+nav a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none; }
+
+.box {
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px; }
+
+.message, .success, .error, .warning {
+    border: 1px solid #ccc;
+    padding: 10px;
+    color: #333; }
+
+.success {
+    border-color: green; }
+
+.error {
+    border-color: red; }
+
+.warning {
+    border-color: yellow; }
+
+.foo:before {
+    content: \\"\\"; }
+
+.bar:before {
+    content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+    font: 100% Helvetica, sans-serif;
+    color: #333; }
+
+nav ul {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+
+nav li {
+    display: inline-block; }
+
+nav a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none; }
+
+.box {
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px; }
+
+.foo:before {
+    content: \\"\\"; }
+
+.bar:before {
+    content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.message, .success, .error, .warning {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  border-color: green; }
+
+.error {
+  border-color: red; }
+
+.warning {
+  border-color: yellow; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.message, .success, .error, .warning {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  border-color: green; }
+
+.error {
+  border-color: red; }
+
+.warning {
+  border-color: yellow; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): css 1`] = `
+"@charset \\"UTF-8\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.foo:before {
+  content: \\"\\"; }
+
+.bar:before {
+  content: \\"∑\\"; }
+"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): warnings 1`] = `Array []`;

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -10,6 +10,10 @@ function getCodeFromSass(testId, options) {
     sassOptions = sassOptions({ mock: true }) || {};
   }
 
+  if (sassOptions.data) {
+    delete sassOptions.data;
+  }
+
   const { implementation } = loaderOptions;
   const isNodeSassImplementation = loaderOptions.implementation.info.includes(
     'node-sass'

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -113,12 +113,31 @@ describe('sassOptions option', () => {
         expect(getErrors(stats)).toMatchSnapshot('errors');
       });
 
-      it(`should work with the "importer" option (${implementationName}) (${syntax})`, async () => {
-        const testId = getTestId('custom-importer', syntax);
+      it(`should ignore the "file" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
         const options = {
           implementation: getImplementationByName(implementationName),
           sassOptions: {
-            importer: customImporter,
+            file: 'test',
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
+      it(`should ignore the "data" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            data: 'test',
           },
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -151,12 +170,107 @@ describe('sassOptions option', () => {
         expect(getErrors(stats)).toMatchSnapshot('errors');
       });
 
+      it(`should work with the "importer" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('custom-importer', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            importer: customImporter,
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
       it(`should work with the "includePaths" option (${implementationName}) (${syntax})`, async () => {
         const testId = getTestId('import-include-paths', syntax);
         const options = {
           implementation: getImplementationByName(implementationName),
           sassOptions: {
             includePaths: [path.resolve(__dirname, syntax, 'includePath')],
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
+      it(`should work with the "indentType" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            indentType: 'tab',
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
+      it(`should work with the "indentWidth" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            indentWidth: 4,
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
+      it(`should work with the "indentedSyntax" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            indentedSyntax: syntax === 'sass',
+          },
+        };
+        const compiler = getCompiler(testId, { loader: { options } });
+        const stats = await compile(compiler);
+        const codeFromBundle = getCodeFromBundle(stats, compiler);
+        const codeFromSass = getCodeFromSass(testId, options);
+
+        expect(codeFromBundle.css).toBe(codeFromSass.css);
+        expect(codeFromBundle.css).toMatchSnapshot('css');
+        expect(getWarnings(stats)).toMatchSnapshot('warnings');
+        expect(getErrors(stats)).toMatchSnapshot('errors');
+      });
+
+      it(`should work with the "linefeed" option (${implementationName}) (${syntax})`, async () => {
+        const testId = getTestId('language', syntax);
+        const options = {
+          implementation: getImplementationByName(implementationName),
+          sassOptions: {
+            linefeed: 'lf',
           },
         };
         const compiler = getCompiler(testId, { loader: { options } });


### PR DESCRIPTION
BREAKING CHANGE: when the `sourceMap` is `true`, `sassOptions.sourceMap`, `sassOptions.sourceMapContents`, `sassOptions.sourceMapEmbed`, `sassOptions.sourceMapRoot` and `sassOptions.omitSourceMapUrl` will be ignored.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

avoid broken sass configuration for sourceMaps

### Breaking Changes

Yes

### Additional Info

No