### PR TITLE
fix: generate absolute sources for source maps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,11 @@ function loader(content) {
       // eslint-disable-next-line no-param-reassign
       result.map = JSON.parse(result.map);
 
+      // eslint-disable-next-line no-console
+      console.log('FROM SASS:');
+      // eslint-disable-next-line no-console
+      console.log(result.map);
+
       // result.map.file is an optional property that provides the output filename.
       // Since we don't know the final filename in the webpack build chain yet, it makes no sense to have it.
       // eslint-disable-next-line no-param-reassign
@@ -77,6 +82,11 @@ function loader(content) {
       result.map.sources = result.map.sources.map((source) =>
         path.resolve(this.rootContext, path.normalize(source))
       );
+
+      // eslint-disable-next-line no-console
+      console.log('FROM LOADER:');
+      // eslint-disable-next-line no-console
+      console.log(result.map);
     }
 
     result.stats.includedFiles.forEach((includedFile) => {

--- a/src/index.js
+++ b/src/index.js
@@ -67,13 +67,16 @@ function loader(content) {
       // eslint-disable-next-line no-param-reassign
       delete result.map.file;
 
+      // eslint-disable-next-line no-param-reassign
+      result.sourceRoot = '';
+
       // node-sass returns POSIX paths, that's why we need to transform them back to native paths.
       // This fixes an error on windows where the source-map module cannot resolve the source maps.
       // @see https://github.com/webpack-contrib/sass-loader/issues/366#issuecomment-279460722
       // eslint-disable-next-line no-param-reassign
-      result.map.sourceRoot = path.normalize(result.map.sourceRoot);
-      // eslint-disable-next-line no-param-reassign
-      result.map.sources = result.map.sources.map(path.normalize);
+      result.map.sources = result.map.sources.map((source) =>
+        path.resolve(this.rootContext, path.normalize(source))
+      );
     }
 
     result.stats.includedFiles.forEach((includedFile) => {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import {
   getSassOptions,
   getWebpackImporter,
   getRenderFunctionFromSassImplementation,
-  absolutifySourceMapSources,
+  absolutifySourceMapSource,
 } from './utils';
 import SassError from './SassError';
 
@@ -84,7 +84,7 @@ function loader(content) {
       // @see https://github.com/webpack-contrib/sass-loader/issues/366#issuecomment-279460722
       // eslint-disable-next-line no-param-reassign
       result.map.sources = result.map.sources.map((source) =>
-        absolutifySourceMapSources(this.rootContext, source)
+        absolutifySourceMapSource(this.rootContext, source)
       );
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,11 +150,12 @@ function getSassOptions(loaderContext, loaderOptions, content, implementation) {
     // But since we're using the data option, the source map will not actually be written, but
     // all paths in sourceMap.sources will be relative to that path.
     // Pretty complicated... :(
-    options.sourceMap = path.join(process.cwd(), '/sass.css.map');
-    options.sourceMapRoot = process.cwd();
+    options.sourceMap = true;
+    options.outFile = path.join(loaderContext.rootContext, 'style.css.map');
+    // options.sourceMapRoot = process.cwd();
     options.sourceMapContents = true;
     options.omitSourceMapUrl = true;
-    options.sourceMapEmbed = false;
+    // options.sourceMapEmbed = false;
   }
 
   const { resourcePath } = loaderContext;

--- a/src/utils.js
+++ b/src/utils.js
@@ -447,7 +447,7 @@ function getURLType(source) {
   return ABSOLUTE_SCHEME.test(source) ? 'absolute' : 'path-relative';
 }
 
-function absolutifySourceMapSources(sourceRoot, source) {
+function absolutifySourceMapSource(sourceRoot, source) {
   const sourceType = getURLType(source);
 
   // Do no touch `scheme-relative`, `path-absolute` and `absolute` types
@@ -463,5 +463,5 @@ export {
   getSassOptions,
   getWebpackImporter,
   getRenderFunctionFromSassImplementation,
-  absolutifySourceMapSources,
+  absolutifySourceMapSource,
 };

--- a/test/sourceMap-options.test.js
+++ b/test/sourceMap-options.test.js
@@ -42,7 +42,9 @@ describe('sourceMap option', () => {
 
         sourceMap.sourceRoot = '';
         sourceMap.sources = sourceMap.sources.map((source) =>
-          source.replace(/\\/g, '/')
+          path
+            .relative(path.resolve(__dirname, '..'), source)
+            .replace(/\\/g, '/')
         );
 
         expect(css).toMatchSnapshot('css');
@@ -124,7 +126,9 @@ describe('sourceMap option', () => {
 
         sourceMap.sourceRoot = '';
         sourceMap.sources = sourceMap.sources.map((source) =>
-          source.replace(/\\/g, '/')
+          path
+            .relative(path.resolve(__dirname, '..'), source)
+            .replace(/\\/g, '/')
         );
 
         expect(css).toMatchSnapshot('css');
@@ -157,7 +161,9 @@ describe('sourceMap option', () => {
 
         sourceMap.sourceRoot = '';
         sourceMap.sources = sourceMap.sources.map((source) =>
-          source.replace(/\\/g, '/')
+          path
+            .relative(path.resolve(__dirname, '..'), source)
+            .replace(/\\/g, '/')
         );
 
         expect(css).toMatchSnapshot('css');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

loaders should generate absolute sources in source maps

### Breaking Changes

No

### Additional Info

No