### PR TITLE
feat: add fixture that fails to resolve to _index.import.scss

### DIFF
--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1454,6 +1454,22 @@ describe("loader", () => {
           expect(getWarnings(stats)).toMatchSnapshot("warnings");
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
+
+        it(`should import .import.${syntax} files without .${syntax} file next to it (${implementationName}) (${syntax})`, async () => {
+          const testId = getTestId("only-import", syntax);
+          const options = {
+            implementation: getImplementationByName(implementationName),
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = getCodeFromSass(testId, options);
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
       }
     });
   });

--- a/test/node_modules/only-import/_index.import.scss
+++ b/test/node_modules/only-import/_index.import.scss
@@ -1,0 +1,3 @@
+a {
+  display: block;
+}

--- a/test/node_modules/only-import/package.json
+++ b/test/node_modules/only-import/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "only-import",
+  "version": "1.0.0",
+  "description": "test",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/sass/only-import.sass
+++ b/test/sass/only-import.sass
@@ -1,0 +1,1 @@
+@import '~only-import'

--- a/test/scss/only-import.scss
+++ b/test/scss/only-import.scss
@@ -1,0 +1,1 @@
+@import '~only-import';


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The resolution of .import.scss files in sass-loader differs from the resolution of sass itself. (#904)

While creating the reproduction I noticed everything works fine if I add a `_index.scss` file next to the `_index.import.scss` file.
That being said, in our case we have files we explicitly only want to expose to `@import` and not to `@use`, so we have files that only exist with the `.import.scss` extension. This works with relative imports in sass but not when using `~` imports via sass-loader.

Adding an extra file without the `.import` in the filename—e.g., a file that contains an `@error` to fail when loaded—is a pretty clean workaround. We'll use that, though it would of course be great if we could skip that.

The error while running the tests:

```
 FAIL  test/loader.test.js (40.018 s)
  ● loader › should import .import.scss files without .scss file next to it (dart-sass) (scss)

    evalmachine.<anonymous>:13
    throw new Error("Module build failed (from ../src/cjs.js):\nSassError: Can't find stylesheet to import.\n  ╷\n1 │ @import '~only-import';\n  │         ^^^^^^^^^^^^^^\n  ╵\n  test/scss/only-import.scss 1:9  root stylesheet");
    ^

    Error: Module build failed (from ../src/cjs.js):
    SassError: Can't find stylesheet to import.
      ╷
    1 │ @import '~only-import';
      │         ^^^^^^^^^^^^^^
      ╵
      test/scss/only-import.scss 1:9  root stylesheet

      at Object../scss/only-import.scss (evalmachine.<anonymous>:13:7)
      at __webpack_require__ (evalmachine.<anonymous>:36:41)
      at evalmachine.<anonymous>:46:18
      at evalmachine.<anonymous>:47:12
      at getCodeFromBundle (test/helpers/getCodeFromBundle.js:21:21)
      at Object.<anonymous> (test/loader.test.js:1465:34)
```