### PR TITLE
docs: resize Sass logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img height="100"
+  <img height="170"
     src="https://worldvectorlogo.com/logos/sass-1.svg">
   <a href="https://github.com/webpack/webpack">
     <img width="200" height="200"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**: Resize Sass logo at readme.

### Motivation / Use-Case

The original size of Sass logo at readme is too small so two logos aren't centered.

### Breaking Changes

No.

### Additional Info

No.
