### PR TITLE
added important information about sass loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ npm install sass-loader sass webpack --save-dev
 
 This allows you to control the versions of all your dependencies, and to choose which Sass implementation to use.
 
-> ℹ️ We recommend using [Dart Sass](https://github.com/sass/dart-sass).
+> ℹ️ We highly recommend using [Dart Sass](https://github.com/sass/dart-sass).
 
-> ⚠ [Node Sass](https://github.com/sass/node-sass) does not work with [Yarn PnP](https://classic.yarnpkg.com/en/docs/pnp/) feature.
+> ⚠ [Node Sass](https://github.com/sass/node-sass) does not work with [Yarn PnP](https://classic.yarnpkg.com/en/docs/pnp/) feature and doesn't support [@use rule](https://sass-lang.com/documentation/at-rules/use).
 
 Chain the `sass-loader` with the [css-loader](https://github.com/webpack-contrib/css-loader) and the [style-loader](https://github.com/webpack-contrib/style-loader) to immediately apply all styles to the DOM or the [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) to extract it into a separate file.
 


### PR DESCRIPTION
When installing node-sass, most of developer don't know that there is a little difference in using some features of sass between them.
[The Sass team discourages the continued use of the @import rule](https://sass-lang.com/documentation/at-rules/import) (it will be deprecated), and they suggest using @use rule instead, which is supported only by dart sass.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ x] **metadata update**

### Motivation / Use-Case

<!--
 When installing node-sass, most of developer don't know that there is a little difference in using some features of sass between them.
[The Sass team discourages the continued use of the @import rule](https://sass-lang.com/documentation/at-rules/import) (it will be deprecated), and they suggest using @use rule instead, which is supported only by dart sass.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
