### PR TITLE
fix: undefined this in proxy importer

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -81,9 +81,9 @@ function proxyCustomImporters(importers, loaderContext) {
   return [].concat(importers).map(
     (importer) =>
       function proxyImporter(...args) {
-        this.webpackLoaderContext = loaderContext;
+        const slef = { webpackLoaderContext: loaderContext };
 
-        return importer.apply(this, args);
+        return importer.apply(slef, args);
       }
   );
 }


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
A fix for [Cannot set property webpackLoaderContext of undefined #955](https://github.com/webpack-contrib/sass-loader/issues/955)
