### PR TITLE
Modern api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.3.2",
         "sass": "^1.45.2",
+        "sass-embedded": "^1.0.0-beta.8",
         "semver": "^7.3.5",
         "standard-version": "^9.3.1",
         "style-loader": "^3.2.1",
@@ -60,6 +61,7 @@
         "fibers": ">= 3.1.0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "sass": "^1.3.0",
+        "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -70,6 +72,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         }
       }
@@ -4223,6 +4228,16 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -5186,6 +5201,21 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha1-MyLNMH2Cltqx9gRhhZOyYaP63o8=",
+      "dev": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -6954,6 +6984,15 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
@@ -7937,6 +7976,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -7996,6 +8070,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fibers": {
@@ -8908,6 +8991,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-protobuf": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.2.tgz",
+      "integrity": "sha512-VVi7/U6WZ5aH11i7/z2kuGHENZXUSZ6VonAp20cnInF0mVaGk3T23eSTIgJ+OjUKEAB4+bHdszseQg29TL+wSg==",
+      "dev": true
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -9374,6 +9463,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ip": {
@@ -12966,6 +13064,40 @@
         "lower-case": "^1.1.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -13814,6 +13946,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -14194,6 +14332,16 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -14481,6 +14629,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/redent": {
@@ -14897,6 +15057,52 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/sass-embedded": {
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.0.0-beta.8.tgz",
+      "integrity": "sha512-SnvTp/gKqFoqj/7DDWWqiZTs/8gCd6WjH0vl2jGOlt/CwxWO8NU0u9Hpo3zUMfHjBvJnVo5HgRfaJSsiAjKvkQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "buffer-builder": "^0.2.0",
+        "extract-zip": "^2.0.1",
+        "google-protobuf": "^3.11.4",
+        "immutable": "^4.0.0",
+        "node-fetch": "^2.6.0",
+        "rxjs": "^7.4.0",
+        "semver": "^7.3.5",
+        "shelljs": "^0.8.4",
+        "supports-color": "^8.1.1",
+        "tar": "^6.0.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/sass-graph": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
@@ -15066,6 +15272,23 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -17243,6 +17466,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
@@ -20636,6 +20869,16 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -21400,6 +21643,18 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha1-MyLNMH2Cltqx9gRhhZOyYaP63o8=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -22753,6 +23008,15 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "enhanced-resolve": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
@@ -23509,6 +23773,29 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -23562,6 +23849,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "fibers": {
@@ -24267,6 +24563,12 @@
         }
       }
     },
+    "google-protobuf": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.2.tgz",
+      "integrity": "sha512-VVi7/U6WZ5aH11i7/z2kuGHENZXUSZ6VonAp20cnInF0mVaGk3T23eSTIgJ+OjUKEAB4+bHdszseQg29TL+wSg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -24619,6 +24921,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -27332,6 +27640,39 @@
         "lower-case": "^1.1.1"
       }
     },
+    "node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -27969,6 +28310,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -28238,6 +28585,16 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -28453,6 +28810,15 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -28774,6 +29140,41 @@
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
+    "sass-embedded": {
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.0.0-beta.8.tgz",
+      "integrity": "sha512-SnvTp/gKqFoqj/7DDWWqiZTs/8gCd6WjH0vl2jGOlt/CwxWO8NU0u9Hpo3zUMfHjBvJnVo5HgRfaJSsiAjKvkQ==",
+      "dev": true,
+      "requires": {
+        "buffer-builder": "^0.2.0",
+        "extract-zip": "^2.0.1",
+        "google-protobuf": "^3.11.4",
+        "immutable": "^4.0.0",
+        "node-fetch": "^2.6.0",
+        "rxjs": "^7.4.0",
+        "semver": "^7.3.5",
+        "shelljs": "^0.8.4",
+        "supports-color": "^8.1.1",
+        "tar": "^6.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "sass-graph": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
@@ -28907,6 +29308,17 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -30613,6 +31025,16 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fibers": ">= 3.1.0",
     "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "sass": "^1.3.0",
+    "sass-embedded": "*",
     "webpack": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -48,6 +49,9 @@
       "optional": true
     },
     "sass": {
+      "optional": true
+    },
+    "sass-embedded": {
       "optional": true
     },
     "fibers": {
@@ -90,6 +94,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
     "sass": "^1.45.2",
+    "sass-embedded": "^1.0.0-beta.8",
     "semver": "^7.3.5",
     "standard-version": "^9.3.1",
     "style-loader": "^3.2.1",

--- a/src/SassError.js
+++ b/src/SassError.js
@@ -5,13 +5,23 @@ class SassError extends Error {
     this.name = "SassError";
     // TODO remove me in the next major release
     this.originalSassError = sassError;
-    this.loc = {
-      line: sassError.line,
-      column: sassError.column,
-    };
+
+    if (
+      typeof sassError.line !== "undefined" ||
+      typeof sassError.column !== "undefined"
+    ) {
+      this.loc = {
+        line: sassError.line,
+        column: sassError.column,
+      };
+    }
 
     // Keep original error if `sassError.formatted` is unavailable
-    this.message = `${this.name}: ${this.originalSassError.message}`;
+    this.message = `${this.name}: ${
+      typeof this.originalSassError.message !== "undefined"
+        ? this.originalSassError.message
+        : this.originalSassError
+    }`;
 
     if (this.originalSassError.formatted) {
       this.message = `${this.name}: ${this.originalSassError.formatted.replace(

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,9 @@ async function loader(content) {
       ? options.webpackImporter
       : true;
 
-  if (shouldUseWebpackImporter) {
+  const isModernAPI = options.api === "modern";
+
+  if (shouldUseWebpackImporter && !isModernAPI) {
     const { includePaths } = sassOptions;
 
     sassOptions.importer.push(

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
   getSassImplementation,
   getSassOptions,
   getWebpackImporter,
+  getModernWebpackImporter,
   getCompileFn,
   normalizeSourceMap,
 } from "./utils";
@@ -44,12 +45,18 @@ async function loader(content) {
 
   const isModernAPI = options.api === "modern";
 
-  if (shouldUseWebpackImporter && !isModernAPI) {
-    const { includePaths } = sassOptions;
+  if (shouldUseWebpackImporter) {
+    if (!isModernAPI) {
+      const { includePaths } = sassOptions;
 
-    sassOptions.importer.push(
-      getWebpackImporter(this, implementation, includePaths)
-    );
+      sassOptions.importer.push(
+        getWebpackImporter(this, implementation, includePaths)
+      );
+    } else {
+      sassOptions.importers.push(
+        getModernWebpackImporter(this, implementation)
+      );
+    }
   }
 
   const compile = getCompileFn(implementation, options);

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,13 @@ async function loader(content) {
     return;
   }
 
-  let map = result.map ? JSON.parse(result.map) : null;
+  let map =
+    // Modern API, then Old API
+    result.sourceMap
+      ? result.sourceMap
+      : result.map
+      ? JSON.parse(result.map)
+      : null;
 
   // Modify source paths only for webpack, otherwise we do nothing
   if (map && useSourceMap) {

--- a/src/options.json
+++ b/src/options.json
@@ -14,6 +14,11 @@
         }
       ]
     },
+    "api": {
+      "description": "Use old or modern API or `sass` (`Dart Sass`) implementation.",
+      "link": "https://github.com/webpack-contrib/sass-loader#sassoptions",
+      "enum": ["old", "modern"]
+    },
     "sassOptions": {
       "description": "Options for `node-sass` or `sass` (`Dart Sass`) implementation.",
       "link": "https://github.com/webpack-contrib/sass-loader#sassoptions",

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,6 +78,9 @@ function getSassImplementation(loaderContext, implementation) {
   } else if (implementationName === "node-sass") {
     // eslint-disable-next-line consistent-return
     return resolvedImplementation;
+  } else if (implementationName === "sass-embedded") {
+    // eslint-disable-next-line consistent-return
+    return resolvedImplementation;
   }
 
   loaderContext.emitError(
@@ -682,9 +685,11 @@ let nodeSassJobQueue = null;
  * @returns {Function}
  */
 function getCompileFn(implementation, options) {
-  const isDartSass = implementation.info.includes("dart-sass");
+  const isNewSass =
+    implementation.info.includes("dart-sass") ||
+    implementation.info.includes("sass-embedded");
 
-  if (isDartSass) {
+  if (isNewSass) {
     if (options.api === "modern") {
       return (sassOptions) => {
         const { data, ...rest } = sassOptions;

--- a/src/utils.js
+++ b/src/utils.js
@@ -192,10 +192,6 @@ async function getSassOptions(
     };
   }
 
-  if (typeof options.charset === "undefined") {
-    options.charset = true;
-  }
-
   const { resourcePath } = loaderContext;
 
   if (isModernAPI) {
@@ -310,6 +306,10 @@ async function getSassOptions(
             )
           : []
       );
+
+    if (typeof options.charset === "undefined") {
+      options.charset = true;
+    }
   }
 
   return options;

--- a/src/utils.js
+++ b/src/utils.js
@@ -747,7 +747,9 @@ function normalizeSourceMap(map, rootContext) {
   // result.map.file is an optional property that provides the output filename.
   // Since we don't know the final filename in the webpack build chain yet, it makes no sense to have it.
   // eslint-disable-next-line no-param-reassign
-  delete newMap.file;
+  if (typeof newMap.file !== "undefined") {
+    delete newMap.file;
+  }
 
   // eslint-disable-next-line no-param-reassign
   newMap.sourceRoot = "";
@@ -759,8 +761,10 @@ function normalizeSourceMap(map, rootContext) {
   newMap.sources = newMap.sources.map((source) => {
     const sourceType = getURLType(source);
 
-    // Do no touch `scheme-relative`, `path-absolute` and `absolute` types
-    if (sourceType === "path-relative") {
+    // Do no touch `scheme-relative`, `path-absolute` and `absolute` types (except `file:`)
+    if (sourceType === "absolute" && /^file:/i.test(source)) {
+      return url.fileURLToPath(source);
+    } else if (sourceType === "path-relative") {
       return path.resolve(rootContext, path.normalize(source));
     }
 

--- a/test/__snapshots__/additionalData-option.test.js.snap
+++ b/test/__snapshots__/additionalData-option.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (sass): css 1`] = `
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: hotpink;
 }
@@ -10,11 +10,11 @@ body {
 }"
 `;
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (scss): css 1`] = `
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "a {
   color: red;
 }
@@ -24,11 +24,11 @@ body {
 }"
 `;
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (sass): css 1`] = `
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: hotpink; }
 
@@ -37,11 +37,11 @@ body {
 "
 `;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (scss): css 1`] = `
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "a {
   color: red; }
 
@@ -50,126 +50,126 @@ body {
 "
 `;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should use same EOL on all os (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (dart-sass) (sass): css 1`] = `
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as a function (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (dart-sass) (scss): css 1`] = `
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as a function (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (node-sass) (sass): css 1`] = `
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as a function (node-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (node-sass) (scss): css 1`] = `
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as a function (node-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a function (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (dart-sass) (sass): css 1`] = `
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as a string (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (dart-sass) (scss): css 1`] = `
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as a string (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (node-sass) (sass): css 1`] = `
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as a string (node-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (node-sass) (scss): css 1`] = `
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as a string (node-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as a string (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (dart-sass) (sass): css 1`] = `
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as an async function (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (dart-sass) (scss): css 1`] = `
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink;
 }"
 `;
 
-exports[`additionalData option should work as an async function (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (node-sass) (sass): css 1`] = `
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as an async function (node-sass) (sass): errors 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (node-sass) (scss): css 1`] = `
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "body {
   color: hotpink; }
 "
 `;
 
-exports[`additionalData option should work as an async function (node-sass) (scss): errors 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`additionalData option should work as an async function (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/additionalData-option.test.js.snap
+++ b/test/__snapshots__/additionalData-option.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: hotpink;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`additionalData option should use same EOL on all os ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: hotpink;
@@ -54,6 +82,26 @@ exports[`additionalData option should use same EOL on all os ('node-sass', 'old'
 
 exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`additionalData option should work as a function ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -94,6 +142,26 @@ exports[`additionalData option should work as a function ('node-sass', 'old' API
 
 exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`additionalData option should work as a string ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -133,6 +201,26 @@ exports[`additionalData option should work as a string ('node-sass', 'old' API, 
 exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`additionalData option should work as an async function ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "body {

--- a/test/__snapshots__/additionalData-option.test.js.snap
+++ b/test/__snapshots__/additionalData-option.test.js.snap
@@ -82,6 +82,62 @@ exports[`additionalData option should use same EOL on all os ('node-sass', 'old'
 
 exports[`additionalData option should use same EOL on all os ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: hotpink;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: hotpink;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -141,6 +197,46 @@ exports[`additionalData option should work as a function ('node-sass', 'old' API
 exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`additionalData option should work as a function ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "body {
@@ -202,6 +298,46 @@ exports[`additionalData option should work as a string ('node-sass', 'old' API, 
 
 exports[`additionalData option should work as a string ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -261,3 +397,43 @@ exports[`additionalData option should work as an async function ('node-sass', 'o
 exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`additionalData option should work as an async function ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/implementation-option.test.js.snap
+++ b/test/__snapshots__/implementation-option.test.js.snap
@@ -16,6 +16,14 @@ exports[`implementation option 'sass_string', 'old' API: errors 1`] = `Array []`
 
 exports[`implementation option 'sass_string', 'old' API: warnings 1`] = `Array []`;
 
+exports[`implementation option 'sass-embedded', 'modern' API: errors 1`] = `Array []`;
+
+exports[`implementation option 'sass-embedded', 'modern' API: warnings 1`] = `Array []`;
+
+exports[`implementation option 'sass-embedded', 'old' API: errors 1`] = `Array []`;
+
+exports[`implementation option 'sass-embedded', 'old' API: warnings 1`] = `Array []`;
+
 exports[`implementation option not specify with modern API: errors 1`] = `Array []`;
 
 exports[`implementation option not specify with modern API: warnings 1`] = `Array []`;

--- a/test/__snapshots__/implementation-option.test.js.snap
+++ b/test/__snapshots__/implementation-option.test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`implementation option 'dart-sass', 'modern' API: errors 1`] = `Array []`;
+
+exports[`implementation option 'dart-sass', 'modern' API: warnings 1`] = `Array []`;
+
 exports[`implementation option 'dart-sass', 'old' API: errors 1`] = `Array []`;
 
 exports[`implementation option 'dart-sass', 'old' API: warnings 1`] = `Array []`;

--- a/test/__snapshots__/implementation-option.test.js.snap
+++ b/test/__snapshots__/implementation-option.test.js.snap
@@ -1,20 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`implementation option dart-sass: errors 1`] = `Array []`;
+exports[`implementation option 'dart-sass', 'old' API: errors 1`] = `Array []`;
 
-exports[`implementation option dart-sass: warnings 1`] = `Array []`;
+exports[`implementation option 'dart-sass', 'old' API: warnings 1`] = `Array []`;
 
-exports[`implementation option node-sass: errors 1`] = `Array []`;
+exports[`implementation option 'node-sass', 'old' API: errors 1`] = `Array []`;
 
-exports[`implementation option node-sass: warnings 1`] = `Array []`;
+exports[`implementation option 'node-sass', 'old' API: warnings 1`] = `Array []`;
+
+exports[`implementation option 'sass_string', 'old' API: errors 1`] = `Array []`;
+
+exports[`implementation option 'sass_string', 'old' API: warnings 1`] = `Array []`;
+
+exports[`implementation option not specify with modern API: errors 1`] = `Array []`;
+
+exports[`implementation option not specify with modern API: warnings 1`] = `Array []`;
+
+exports[`implementation option not specify with old API: errors 1`] = `Array []`;
+
+exports[`implementation option not specify with old API: warnings 1`] = `Array []`;
 
 exports[`implementation option not specify: errors 1`] = `Array []`;
 
 exports[`implementation option not specify: warnings 1`] = `Array []`;
-
-exports[`implementation option sass_string: errors 1`] = `Array []`;
-
-exports[`implementation option sass_string: warnings 1`] = `Array []`;
 
 exports[`implementation option should not swallow an error when trying to load a sass implementation: errors 1`] = `
 Array [

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -56,11 +56,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -98,11 +98,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -150,11 +150,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -188,11 +188,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -248,11 +248,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -290,11 +290,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -342,11 +342,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -380,11 +380,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -440,11 +440,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -482,11 +482,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -534,11 +534,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -572,11 +572,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -632,11 +632,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -674,11 +674,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -737,11 +737,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -782,41 +782,41 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (sass): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (scss): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.success,.error,.warning{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:yellow}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
 "
 `;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
 "
 `;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -872,11 +872,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -914,11 +914,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -966,11 +966,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1004,11 +1004,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1064,11 +1064,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1106,11 +1106,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1158,11 +1158,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1196,11 +1196,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1256,11 +1256,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1298,11 +1298,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1350,11 +1350,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1388,11 +1388,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1448,11 +1448,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1490,11 +1490,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1542,11 +1542,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1580,11 +1580,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1640,11 +1640,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1682,11 +1682,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1734,11 +1734,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1772,11 +1772,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Object" (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1832,11 +1832,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1874,11 +1874,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1926,11 +1926,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1964,53 +1964,53 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "h2, h3, h4, h5 {
   color: #08c;
 }"
 `;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "h2, h3, h4, h5 {
   color: #08c;
 }"
 `;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "h2, h3, h4, h5 {
   color: #08c; }
 "
 `;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "h2, h3, h4, h5 {
   color: #08c; }
 "
 `;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "functions" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): css 2`] = `
 ".a {
   color: red;
 }
@@ -2020,17 +2020,17 @@ exports[`sassOptions option should work with the "importer" as a array of functi
 }"
 `;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (sass): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): css 2`] = `
 ".a {
   color: red;
 }
@@ -2040,17 +2040,17 @@ exports[`sassOptions option should work with the "importer" as a array of functi
 }"
 `;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (dart-sass) (scss): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): css 2`] = `
 ".a {
   color: red; }
 
@@ -2059,17 +2059,17 @@ exports[`sassOptions option should work with the "importer" as a array of functi
 "
 `;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (sass): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'sass' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): css 2`] = `
 ".a {
   color: red; }
 
@@ -2078,79 +2078,79 @@ exports[`sassOptions option should work with the "importer" as a array of functi
 "
 `;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a array of functions option (node-sass) (scss): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a array of functions option ('node-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): css 2`] = `
 ".a {
   color: red;
 }"
 `;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (sass): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'sass' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): css 2`] = `
 ".a {
   color: red;
 }"
 `;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (dart-sass) (scss): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('dart-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): css 2`] = `
 ".a {
   color: red; }
 "
 `;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (sass): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'sass' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): css 1`] = `""`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `""`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): css 2`] = `
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): css 2`] = `
 ".a {
   color: red; }
 "
 `;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): errors 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): errors 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "importer" as a single function option (node-sass) (scss): warnings 2`] = `Array []`;
+exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -2160,11 +2160,11 @@ exports[`sassOptions option should work with the "includePaths" option (dart-sas
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -2174,11 +2174,11 @@ exports[`sassOptions option should work with the "includePaths" option (dart-sas
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -2187,11 +2187,11 @@ exports[`sassOptions option should work with the "includePaths" option (node-sas
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -2200,11 +2200,11 @@ exports[`sassOptions option should work with the "includePaths" option (node-sas
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2260,11 +2260,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2302,11 +2302,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2354,11 +2354,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2392,11 +2392,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2452,11 +2452,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2494,11 +2494,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2546,11 +2546,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2584,11 +2584,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2644,11 +2644,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2686,11 +2686,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2738,11 +2738,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2776,11 +2776,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2836,11 +2836,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2878,11 +2878,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): css 1`] = `
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2930,11 +2930,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): css 1`] = `
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2968,6 +2968,6 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -192,6 +192,108 @@ exports[`sassOptions option should don't use the "fibers" package when the "fibe
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -383,6 +485,108 @@ nav a {
 exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -786,6 +990,18 @@ exports[`sassOptions option should respect the "outputStyle" option ('node-sass'
 
 exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
@@ -815,6 +1031,108 @@ exports[`sassOptions option should use "compressed" output style in the "product
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1007,6 +1325,108 @@ nav a {
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1392,6 +1812,108 @@ exports[`sassOptions option should work when the option like "Function" ('node-s
 
 exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1775,6 +2297,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2588,6 +3212,108 @@ exports[`sassOptions option should work with the "indentWidth" option ('node-sas
 
 exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2779,6 +3505,108 @@ nav a {
 exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1908,6 +1908,162 @@ exports[`sassOptions option should respect the "outputStyle" option ('sass-embed
 
 exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+"﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.success,.error,.warning{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:yellow}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
+"
+`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+"﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
+"
+`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -56,11 +56,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -98,9 +98,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -191,108 +191,6 @@ nav a {
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -894,108 +792,6 @@ exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'o
 
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1188,108 +984,6 @@ exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' 
 
 exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1392,7 +1086,7 @@ exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'o
 
 exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1448,11 +1142,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1490,11 +1184,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1550,11 +1244,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1592,11 +1286,215 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1655,11 +1553,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1700,11 +1598,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1760,11 +1658,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1802,11 +1700,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1862,11 +1760,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1904,9 +1802,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
 
@@ -2064,6 +1962,66 @@ exports[`sassOptions option should use "compressed" output style in the "product
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2195,108 +2153,6 @@ nav a {
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -4392,7 +4248,7 @@ exports[`sassOptions option should work when the option like "Object" ('sass-emb
 
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -4448,51 +4304,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -4625,108 +4439,6 @@ nav a {
 exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -5032,7 +4744,7 @@ exports[`sassOptions option should work with the "importer" as a single function
 
 exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -5042,11 +4754,11 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -5056,39 +4768,11 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
-".include-path-module {
-  background: hotpink;
-}
-
-._underscore-include-path-module {
-  background: hotpink;
-}"
-`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
-".include-path-module {
-  background: hotpink;
-}
-
-._underscore-include-path-module {
-  background: hotpink;
-}"
-`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -5097,11 +4781,11 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -5110,139 +4794,9 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-".include-path-module {
-  background: hotpink;
-}
-
-._underscore-include-path-module {
-  background: hotpink;
-}"
-`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-".include-path-module {
-  background: hotpink;
-}
-
-._underscore-include-path-module {
-  background: hotpink;
-}"
-`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -5436,108 +4990,6 @@ exports[`sassOptions option should work with the "indentType" option ('node-sass
 
 exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -5639,108 +5091,6 @@ nav a {
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -5934,108 +5284,6 @@ exports[`sassOptions option should work with the "indentWidth" option ('node-sas
 
 exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -6138,7 +5386,7 @@ exports[`sassOptions option should work with the "indentWidth" option ('sass-emb
 
 exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6194,11 +5442,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6236,11 +5484,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6296,11 +5544,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6338,11 +5586,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -6390,11 +5638,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -6428,11 +5676,11 @@ nav a {
 "
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6488,11 +5736,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6530,113 +5778,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6692,11 +5838,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -6734,9 +5880,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -6929,108 +6075,6 @@ nav a {
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -4870,6 +4870,26 @@ exports[`sassOptions option should work with the "functions" option ('node-sass'
 
 exports[`sassOptions option should work with the "functions" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"h1 {
+  font-size: 32px;
+}"
+`;
+
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"h1 {
+  font-size: 32px;
+}"
+`;
+
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "functions" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `""`;
 
 exports[`sassOptions option should work with the "importer" as a array of functions option ('dart-sass', 'old' API, 'sass' syntax): css 2`] = `

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1,209 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
@@ -294,7 +90,7 @@ exports[`sassOptions option should don't use the "fibers" package when the "fibe
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -350,11 +146,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -392,9 +188,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -588,7 +384,7 @@ exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' 
 
 exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -644,11 +440,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -686,9 +482,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -882,7 +678,7 @@ exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' 
 
 exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -938,11 +734,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -980,9 +776,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1194,49 +990,7 @@ exports[`sassOptions option should respect the "outputStyle" option ('node-sass'
 
 exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `"﻿@import\\"./file.css\\";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}"`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
-"﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.success,.error,.warning{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:yellow}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
-"
-`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
-"﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:\\"\\"}.bar:before{content:\\"∑\\"}
-"
-`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1292,11 +1046,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1334,9 +1088,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1530,7 +1284,7 @@ exports[`sassOptions option should use the "fibers" package if it is possible ('
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1586,11 +1340,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1628,9 +1382,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1824,7 +1578,7 @@ exports[`sassOptions option should work when the option is empty "Object" ('node
 
 exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1880,11 +1634,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1922,9 +1676,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2118,7 +1872,7 @@ exports[`sassOptions option should work when the option like "Function" ('node-s
 
 exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2174,11 +1928,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2216,9 +1970,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2412,6 +2166,108 @@ exports[`sassOptions option should work when the option like "Function" and neve
 
 exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2604,7 +2460,7 @@ exports[`sassOptions option should work when the option like "Object" ('node-sas
 
 exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2660,11 +2516,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2702,9 +2558,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2898,6 +2754,108 @@ exports[`sassOptions option should work with the "fiber" option ('node-sass', 'o
 
 exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "functions" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "h2, h3, h4, h5 {
   color: #08c;
@@ -3080,6 +3038,34 @@ exports[`sassOptions option should work with the "importer" as a single function
 
 exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
@@ -3134,107 +3120,33 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
 }
 
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
+._underscore-include-path-module {
+  background: hotpink;
 }"
 `;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
 }
 
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
+._underscore-include-path-module {
+  background: hotpink;
 }"
 `;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3428,7 +3340,7 @@ exports[`sassOptions option should work with the "indentType" option ('node-sass
 
 exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -3484,11 +3396,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -3526,9 +3438,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3722,7 +3634,7 @@ exports[`sassOptions option should work with the "indentWidth" option ('node-sas
 
 exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -3778,11 +3690,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -3820,9 +3732,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -4016,7 +3928,7 @@ exports[`sassOptions option should work with the "indentedSyntax" option ('node-
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -4072,11 +3984,11 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -4114,9 +4026,9 @@ nav a {
 }"
 `;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -4309,3 +4221,105 @@ nav a {
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -779,6 +881,108 @@ nav a {
 exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1619,6 +1823,108 @@ nav a {
 exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2774,7 +3080,7 @@ exports[`sassOptions option should work with the "importer" as a single function
 
 exports[`sassOptions option should work with the "importer" as a single function option ('node-sass', 'old' API, 'scss' syntax): warnings 2`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -2784,11 +3090,11 @@ exports[`sassOptions option should work with the "includePaths" option ('dart-sa
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink;
 }
@@ -2798,11 +3104,11 @@ exports[`sassOptions option should work with the "includePaths" option ('dart-sa
 }"
 `;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -2811,11 +3117,11 @@ exports[`sassOptions option should work with the "includePaths" option ('node-sa
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
 
@@ -2824,9 +3130,111 @@ exports[`sassOptions option should work with the "includePaths" option ('node-sa
 "
 `;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sassOptions option should work with the "includePaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3019,6 +3427,108 @@ nav a {
 exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
@@ -89,6 +191,108 @@ nav a {
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -191,6 +395,108 @@ nav a {
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should don't use the "fibers" package when the "fiber" option is "false" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "data" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -384,6 +690,108 @@ exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' 
 
 exports[`sassOptions option should ignore the "data" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -485,6 +893,108 @@ nav a {
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "file" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -678,6 +1188,108 @@ exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' 
 
 exports[`sassOptions option should ignore the "file" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -779,6 +1391,108 @@ nav a {
 exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should ignore the "file" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should respect the "outputStyle" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -990,6 +1704,108 @@ exports[`sassOptions option should respect the "outputStyle" option ('node-sass'
 
 exports[`sassOptions option should respect the "outputStyle" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1091,66 +1907,6 @@ nav a {
 exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should respect the "outputStyle" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1284,6 +2040,108 @@ exports[`sassOptions option should use the "fibers" package if it is possible ('
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1385,6 +2243,108 @@ nav a {
 exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should use the "fibers" package if it is possible ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1578,6 +2538,108 @@ exports[`sassOptions option should work when the option is empty "Object" ('node
 
 exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1679,6 +2741,108 @@ nav a {
 exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1872,6 +3036,108 @@ exports[`sassOptions option should work when the option like "Function" ('node-s
 
 exports[`sassOptions option should work when the option like "Function" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1973,6 +3239,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2166,6 +3534,108 @@ exports[`sassOptions option should work when the option like "Function" and neve
 
 exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2267,6 +3737,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2460,6 +4032,108 @@ exports[`sassOptions option should work when the option like "Object" ('node-sas
 
 exports[`sassOptions option should work when the option like "Object" ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2561,66 +4235,6 @@ nav a {
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -2753,6 +4367,108 @@ nav a {
 exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "fiber" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3148,6 +4864,108 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -3340,6 +5158,108 @@ exports[`sassOptions option should work with the "indentType" option ('node-sass
 
 exports[`sassOptions option should work with the "indentType" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -3441,6 +5361,108 @@ nav a {
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentType" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentWidth" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3634,6 +5656,108 @@ exports[`sassOptions option should work with the "indentWidth" option ('node-sas
 
 exports[`sassOptions option should work with the "indentWidth" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -3735,6 +5859,108 @@ nav a {
 exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentWidth" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3928,6 +6154,108 @@ exports[`sassOptions option should work with the "indentedSyntax" option ('node-
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -4029,6 +6357,108 @@ nav a {
 exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "indentedSyntax" option ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -4221,6 +6651,108 @@ nav a {
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sassOptions option should work with the "linefeed" option ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -4392,6 +4392,108 @@ exports[`sassOptions option should work when the option like "Object" ('sass-emb
 
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sassOptions option should work with the "fiber" option ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -610,6 +610,264 @@ nav {
 
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `
+Object {
+  "file": "style.css.map",
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "sass/language.sass",
+    "sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `
+Object {
+  "file": "style.css.map",
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "scss/language.scss",
+    "scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1215,6 +1473,262 @@ nav {
 `;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1822,6 +2336,262 @@ nav {
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2428,6 +3198,262 @@ nav {
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2733,6 +3759,218 @@ exports[`sourceMap option should not generate source maps when value has "false"
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -3040,6 +4278,218 @@ exports[`sourceMap option should not generate source maps when value has "false"
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -3345,3 +4795,215 @@ exports[`sourceMap option should not generate source maps when value is not spec
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -56,9 +56,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "file": "style.css.map",
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
@@ -136,9 +136,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -176,9 +176,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "file": "style.css.map",
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
@@ -245,9 +245,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -295,9 +295,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "file": "style.css.map",
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,ECzDO,IAAO,GDyDO",
@@ -375,9 +375,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -411,9 +411,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "file": "style.css.map",
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC7CO,IAAO,GD8CtB",
@@ -480,9 +480,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -538,9 +538,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
   "names": Array [],
@@ -617,9 +617,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -657,9 +657,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
   "names": Array [],
@@ -725,9 +725,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -775,9 +775,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,ECzDO,IAAO,GDyDO",
   "names": Array [],
@@ -854,9 +854,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -890,9 +890,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC7CO,IAAO,GD8CtB",
   "names": Array [],
@@ -958,9 +958,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1016,9 +1016,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
   "names": Array [],
@@ -1095,9 +1095,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1135,9 +1135,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
   "names": Array [],
@@ -1203,9 +1203,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1253,9 +1253,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,ECzDO,IAAO,GDyDO",
   "names": Array [],
@@ -1332,9 +1332,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1368,9 +1368,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC7CO,IAAO,GD8CtB",
   "names": Array [],
@@ -1436,9 +1436,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1494,9 +1494,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
   "names": Array [],
@@ -1573,9 +1573,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1613,9 +1613,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
   "names": Array [],
@@ -1681,9 +1681,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1731,9 +1731,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (sass): source map 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,ECzDO,IAAO,GDyDO",
   "names": Array [],
@@ -1810,9 +1810,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -1846,9 +1846,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (scss): source map 1`] = `
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `
 Object {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AAMP,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC7CO,IAAO,GD8CtB",
   "names": Array [],
@@ -1914,9 +1914,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -1972,13 +1972,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2016,13 +2016,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2070,13 +2070,13 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2110,13 +2110,13 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2172,13 +2172,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2216,13 +2216,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2270,13 +2270,13 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2310,13 +2310,13 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2372,13 +2372,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -2416,13 +2416,13 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (sass): css 1`] = `
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2470,13 +2470,13 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (sass): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (sass): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (scss): css 1`] = `
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -2510,8 +2510,8 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (scss): errors 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (scss): source map 1`] = `undefined`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
-exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -1,5 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -482,6 +610,134 @@ nav {
 
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -959,6 +1215,134 @@ nav {
 `;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -1438,6 +1822,134 @@ nav {
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+Object {
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": Array [],
+  "sourceRoot": "",
+  "sources": Array [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -1916,6 +2428,112 @@ nav {
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2116,6 +2734,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -2315,6 +3039,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -69,49 +69,49 @@ exports[`validate options should throw an error on the "sourceMap" option with "
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
+   object { implementation?, api?, sassOptions?, additionalData?, sourceMap?, webpackImporter?, warnRuleAsWarning? }"
 `;
 
 exports[`validate options should throw an error on the "warnRuleAsWarning" option with "string" value 1`] = `

--- a/test/__snapshots__/warnRuleAsWarning.test.js.snap
+++ b/test/__snapshots__/warnRuleAsWarning.test.js.snap
@@ -1,5 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning by default ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -88,6 +152,70 @@ exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scs
 
 exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -175,6 +303,62 @@ exports[`loader should not emit warning when 'false' used ('node-sass', 'old' AP
 exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
 
 exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `
+Array [
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `
+Array [
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
 
 exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {

--- a/test/__snapshots__/warnRuleAsWarning.test.js.snap
+++ b/test/__snapshots__/warnRuleAsWarning.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loader should not emit warning by default (dart-sass) (sass): css 1`] = `
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning by default (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning by default (dart-sass) (sass): logs 1`] = `
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'sass' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -30,17 +30,17 @@ test/sass/logging.sass 2:1  root stylesheet
 ]
 `;
 
-exports[`loader should not emit warning by default (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`loader should not emit warning by default (dart-sass) (scss): css 1`] = `
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning by default (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning by default (dart-sass) (scss): logs 1`] = `
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'scss' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -62,17 +62,41 @@ test/scss/logging.scss 2:1  root stylesheet
 ]
 `;
 
-exports[`loader should not emit warning by default (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`loader should not emit warning by default ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (sass): css 1`] = `
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (sass): logs 1`] = `
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'sass' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -94,17 +118,17 @@ test/sass/logging.sass 2:1  root stylesheet
 ]
 `;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (scss): css 1`] = `
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (scss): logs 1`] = `
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'scss' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -126,17 +150,41 @@ test/scss/logging.scss 2:1  root stylesheet
 ]
 `;
 
-exports[`loader should not emit warning when 'false' used (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (sass): css 1`] = `
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (sass): logs 1`] = `
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'sass' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -149,22 +197,22 @@ Array [
 ]
 `;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (sass): warnings 1`] = `
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `
 Array [
   "ModuleWarning: Module Warning (from ../src/cjs.js):
 My warning message",
 ]
 `;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (scss): css 1`] = `
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "a {
   color: red;
 }"
 `;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (scss): logs 1`] = `
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'scss' syntax): logs 1`] = `
 Array [
   Array [
     Object {
@@ -177,9 +225,33 @@ Array [
 ]
 `;
 
-exports[`loader should not emit warning when 'true' used (dart-sass) (scss): warnings 1`] = `
+exports[`loader should not emit warning when 'true' used ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `
 Array [
   "ModuleWarning: Module Warning (from ../src/cjs.js):
 My warning message",
 ]
 `;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red; }
+"
+`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/warnRuleAsWarning.test.js.snap
+++ b/test/__snapshots__/warnRuleAsWarning.test.js.snap
@@ -152,6 +152,94 @@ exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scs
 
 exports[`loader should not emit warning by default ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning by default ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -304,6 +392,94 @@ exports[`loader should not emit warning when 'false' used ('node-sass', 'old' AP
 
 exports[`loader should not emit warning when 'false' used ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+    Object {
+      "args": Array [
+        "My warning message
+
+test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`loader should not emit warning when 'true' used ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -439,3 +615,83 @@ exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API
 exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
 
 exports[`loader should not emit warning when 'true' used ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'sass' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/sass/logging.sass:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `
+Array [
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'scss' syntax): logs 1`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [
+        "file:///<cwd>/scss/logging.scss:0:0: My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `
+Array [
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'sass' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'scss' syntax): logs 1`] = `Array []`;
+
+exports[`loader should not emit warning when 'true' used ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/webpackImporter-options.test.js.snap
+++ b/test/__snapshots__/webpackImporter-options.test.js.snap
@@ -1,107 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.message, .warning, .error, .success {
-  border: 1px solid #ccc;
-  padding: 10px;
-  color: #333;
-}
-
-.success {
-  border-color: green;
-}
-
-.error {
-  border-color: red;
-}
-
-.warning {
-  border-color: yellow;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
-
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
-
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
-"@charset \\"UTF-8\\";
-@import \\"./file.css\\";
-body {
-  font: 100% Helvetica, sans-serif;
-  color: #333;
-}
-
-nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-nav li {
-  display: inline-block;
-}
-nav a {
-  display: block;
-  padding: 6px 12px;
-  text-decoration: none;
-}
-
-.box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
-}
-
-.foo:before {
-  content: \\"\\\\e0c6\\";
-}
-
-.bar:before {
-  content: \\"∑\\";
-}"
-`;
-
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
-
-exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
-
 exports[`webpackImporter option false ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -294,7 +192,7 @@ exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): e
 
 exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -350,11 +248,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -392,9 +290,9 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -588,7 +486,7 @@ exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' synt
 
 exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -644,11 +542,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -686,9 +584,9 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`webpackImporter option true ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
@@ -881,3 +779,105 @@ nav a {
 exports[`webpackImporter option true ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`webpackImporter option true ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option true ('sass-embedded', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/webpackImporter-options.test.js.snap
+++ b/test/__snapshots__/webpackImporter-options.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webpackImporter option false (dart-sass) (sass): css 1`] = `
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -56,11 +56,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option false (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option false (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option false (dart-sass) (scss): css 1`] = `
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -98,11 +98,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option false (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option false (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option false (node-sass) (sass): css 1`] = `
+exports[`webpackImporter option false ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -150,11 +150,11 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option false (node-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option false (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option false (node-sass) (scss): css 1`] = `
+exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -188,11 +188,11 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option false (node-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option false (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (dart-sass) (sass): css 1`] = `
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -248,11 +248,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option not specify (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (dart-sass) (scss): css 1`] = `
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -290,11 +290,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option not specify (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (node-sass) (sass): css 1`] = `
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -342,11 +342,11 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option not specify (node-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (node-sass) (scss): css 1`] = `
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -380,11 +380,11 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option not specify (node-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option not specify (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true (dart-sass) (sass): css 1`] = `
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -440,11 +440,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option true (dart-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true (dart-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true (dart-sass) (scss): css 1`] = `
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
 body {
@@ -482,11 +482,11 @@ nav a {
 }"
 `;
 
-exports[`webpackImporter option true (dart-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true (dart-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option true ('dart-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true (node-sass) (sass): css 1`] = `
+exports[`webpackImporter option true ('node-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -534,11 +534,11 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option true (node-sass) (sass): errors 1`] = `Array []`;
+exports[`webpackImporter option true ('node-sass', 'old' API, 'sass' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true (node-sass) (sass): warnings 1`] = `Array []`;
+exports[`webpackImporter option true ('node-sass', 'old' API, 'sass' syntax): warnings 1`] = `Array []`;
 
-exports[`webpackImporter option true (node-sass) (scss): css 1`] = `
+exports[`webpackImporter option true ('node-sass', 'old' API, 'scss' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import url(./file.css);
 body {
@@ -572,6 +572,6 @@ nav a {
 "
 `;
 
-exports[`webpackImporter option true (node-sass) (scss): errors 1`] = `Array []`;
+exports[`webpackImporter option true ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
-exports[`webpackImporter option true (node-sass) (scss): warnings 1`] = `Array []`;
+exports[`webpackImporter option true ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;

--- a/test/__snapshots__/webpackImporter-options.test.js.snap
+++ b/test/__snapshots__/webpackImporter-options.test.js.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option false ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`webpackImporter option false ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -192,6 +294,108 @@ exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): e
 
 exports[`webpackImporter option false ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
 
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option not specify ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
+
 exports[`webpackImporter option not specify ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";
 @import \\"./file.css\\";
@@ -383,6 +587,108 @@ nav a {
 exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): errors 1`] = `Array []`;
 
 exports[`webpackImporter option not specify ('node-sass', 'old' API, 'scss' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `Array []`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset \\"UTF-8\\";
+@import \\"./file.css\\";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: \\"\\\\e0c6\\";
+}
+
+.bar:before {
+  content: \\"∑\\";
+}"
+`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `Array []`;
+
+exports[`webpackImporter option true ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `Array []`;
 
 exports[`webpackImporter option true ('dart-sass', 'old' API, 'sass' syntax): css 1`] = `
 "@charset \\"UTF-8\\";

--- a/test/additionalData-option.test.js
+++ b/test/additionalData-option.test.js
@@ -47,7 +47,7 @@ describe("additionalData option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -72,7 +72,7 @@ describe("additionalData option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -97,7 +97,7 @@ describe("additionalData option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");

--- a/test/helpers/customFunctions.js
+++ b/test/helpers/customFunctions.js
@@ -1,29 +1,35 @@
 export default (api, implementation) => {
+  if (api === "modern") {
+    return {
+      // Note: in real code, you should use `math.pow()` from the built-in
+      // `sass:math` module.
+      // eslint-disable-next-line func-names
+      "pow($base, $exponent)": function (args) {
+        const base = args[0].assertNumber("base").assertNoUnits("base");
+        const exponent = args[1]
+          .assertNumber("exponent")
+          .assertNoUnits("exponent");
+
+        // eslint-disable-next-line no-restricted-properties
+        return new implementation.SassNumber(
+          Math.pow(base.value, exponent.value)
+        );
+      },
+    };
+  }
+
   return {
-    "headings($from: 0, $to: 6)":
-      api === "modern"
-        ? (args) => {
-            const [f, t] = args;
-            const list = new implementation.SassList(t - f + 1);
-            let i;
+    "headings($from: 0, $to: 6)": (from, to) => {
+      const f = from.getValue();
+      const t = to.getValue();
+      const list = new implementation.types.List(t - f + 1);
+      let i;
 
-            for (i = f; i <= t; i++) {
-              list.setValue(i - f, new implementation.SassString(`h${i}`));
-            }
+      for (i = f; i <= t; i++) {
+        list.setValue(i - f, new implementation.types.String(`h${i}`));
+      }
 
-            return implementation.SassString(`h1`);
-          }
-        : (from, to) => {
-            const f = from.getValue();
-            const t = to.getValue();
-            const list = new implementation.types.List(t - f + 1);
-            let i;
-
-            for (i = f; i <= t; i++) {
-              list.setValue(i - f, new implementation.types.String(`h${i}`));
-            }
-
-            return list;
-          },
+      return list;
+    },
   };
 };

--- a/test/helpers/customFunctions.js
+++ b/test/helpers/customFunctions.js
@@ -1,16 +1,29 @@
-export default (implementation) => {
+export default (api, implementation) => {
   return {
-    "headings($from: 0, $to: 6)": (from, to) => {
-      const f = from.getValue();
-      const t = to.getValue();
-      const list = new implementation.types.List(t - f + 1);
-      let i;
+    "headings($from: 0, $to: 6)":
+      api === "modern"
+        ? (args) => {
+            const [f, t] = args;
+            const list = new implementation.SassList(t - f + 1);
+            let i;
 
-      for (i = f; i <= t; i++) {
-        list.setValue(i - f, new implementation.types.String(`h${i}`));
-      }
+            for (i = f; i <= t; i++) {
+              list.setValue(i - f, new implementation.SassString(`h${i}`));
+            }
 
-      return list;
-    },
+            return implementation.SassString(`h1`);
+          }
+        : (from, to) => {
+            const f = from.getValue();
+            const t = to.getValue();
+            const list = new implementation.types.List(t - f + 1);
+            let i;
+
+            for (i = f; i <= t; i++) {
+              list.setValue(i - f, new implementation.types.String(`h${i}`));
+            }
+
+            return list;
+          },
   };
 };

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -38,9 +38,10 @@ async function getCodeFromSass(testId, options) {
       isIndentedSyntax ? "\n" : ";"
     }\n${fs.readFileSync(path.resolve(__dirname, "..", testId), "utf8")}`;
   } else if (isModernAPI) {
-    sassOptions.data = fs
-      .readFileSync(url.pathToFileURL(path.resolve(__dirname, "..", testId)))
-      .toString();
+    const URL = url.pathToFileURL(path.resolve(__dirname, "..", testId));
+
+    sassOptions.url = URL;
+    sassOptions.data = fs.readFileSync(URL).toString();
   } else {
     sassOptions.file = path.resolve(__dirname, "..", testId);
   }

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -811,6 +811,10 @@ async function getCodeFromSass(testId, options) {
     ));
   } else {
     ({ css, map } = await new Promise((resolve, reject) => {
+      if (sassOptions.fiber === false) {
+        delete sassOptions.fiber;
+      }
+
       implementation.render(sassOptions, (error, result) => {
         if (error) {
           reject(error);

--- a/test/helpers/getImplementationsAndAPI.js
+++ b/test/helpers/getImplementationsAndAPI.js
@@ -1,0 +1,22 @@
+import nodeSass from "node-sass";
+import dartSass from "sass";
+
+export default function getImplementationsAndAPI() {
+  return [
+    {
+      name: nodeSass.info.split("\t")[0],
+      implementation: nodeSass,
+      api: "old",
+    },
+    {
+      name: dartSass.info.split("\t")[0],
+      implementation: dartSass,
+      api: "old",
+    },
+    // {
+    //   name: dartSass.info.split("\t")[0],
+    //   implementation: dartSass,
+    //   api: "modern",
+    // },
+  ];
+}

--- a/test/helpers/getImplementationsAndAPI.js
+++ b/test/helpers/getImplementationsAndAPI.js
@@ -13,10 +13,10 @@ export default function getImplementationsAndAPI() {
       implementation: dartSass,
       api: "old",
     },
-    // {
-    //   name: dartSass.info.split("\t")[0],
-    //   implementation: dartSass,
-    //   api: "modern",
-    // },
+    {
+      name: dartSass.info.split("\t")[0],
+      implementation: dartSass,
+      api: "modern",
+    },
   ];
 }

--- a/test/helpers/getImplementationsAndAPI.js
+++ b/test/helpers/getImplementationsAndAPI.js
@@ -1,5 +1,7 @@
 import nodeSass from "node-sass";
 import dartSass from "sass";
+// eslint-disable-next-line import/no-namespace
+import * as SassEmbedded from "sass-embedded";
 
 export default function getImplementationsAndAPI() {
   return [
@@ -16,6 +18,16 @@ export default function getImplementationsAndAPI() {
     {
       name: dartSass.info.split("\t")[0],
       implementation: dartSass,
+      api: "modern",
+    },
+    {
+      name: SassEmbedded.info.split("\t")[0],
+      implementation: SassEmbedded,
+      api: "old",
+    },
+    {
+      name: SassEmbedded.info.split("\t")[0],
+      implementation: SassEmbedded,
       api: "modern",
     },
   ];

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -6,6 +6,7 @@ import getCodeFromSass from "./getCodeFromSass";
 import getCompiler from "./getCompiler";
 import getErrors from "./getErrors";
 import getImplementationByName from "./getImplementationByName";
+import getImplementationsAndAPI from "./getImplementationsAndAPI";
 import getTestId from "./getTestId";
 import getWarnings from "./getWarnings";
 import readAsset from "./readAsset";
@@ -19,6 +20,7 @@ export {
   getCompiler,
   getErrors,
   getImplementationByName,
+  getImplementationsAndAPI,
   getTestId,
   getWarnings,
   readAsset,

--- a/test/implementation-option.test.js
+++ b/test/implementation-option.test.js
@@ -1,5 +1,7 @@
 import nodeSass from "node-sass";
 import dartSass from "sass";
+// eslint-disable-next-line import/no-namespace
+import * as sassEmbedded from "sass-embedded";
 
 import { isSupportedFibers } from "../src/utils";
 
@@ -52,6 +54,11 @@ describe("implementation option", () => {
       const nodeSassSpy = jest.spyOn(nodeSass, "render");
       const dartSassSpy = jest.spyOn(dartSass, "render");
       const dartSassSpyModernAPI = jest.spyOn(dartSass, "compileStringAsync");
+      const sassEmbeddedSpy = jest.spyOn(sassEmbedded, "render");
+      const sassEmbeddedSpyModernAPI = jest.spyOn(
+        sassEmbedded,
+        "compileStringAsync"
+      );
 
       const testId = getTestId("language", "scss");
       const options = { api, implementation };
@@ -69,6 +76,8 @@ describe("implementation option", () => {
         expect(nodeSassSpy).toHaveBeenCalledTimes(1);
         expect(dartSassSpy).toHaveBeenCalledTimes(0);
         expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+        expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+        expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
       } else if (
         implementationName === "dart-sass" ||
         implementationName === "dart-sass_string"
@@ -77,16 +86,36 @@ describe("implementation option", () => {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(1);
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
         } else if (api === "old") {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(1);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+        }
+      } else if (implementationName === "sass-embedded") {
+        if (api === "modern") {
+          expect(nodeSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(1);
+        } else if (api === "old") {
+          expect(nodeSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(1);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
         }
       }
 
       nodeSassSpy.mockRestore();
       dartSassSpy.mockRestore();
       dartSassSpyModernAPI.mockRestore();
+      sassEmbeddedSpy.mockRestore();
+      sassEmbeddedSpyModernAPI.mockRestore();
     });
   });
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -51,7 +51,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -80,7 +80,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -110,7 +110,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -127,7 +127,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -221,7 +221,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -239,7 +239,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -257,7 +257,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -274,7 +274,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -291,7 +291,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -308,7 +308,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -328,7 +328,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -349,7 +349,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -366,7 +366,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -383,7 +383,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -400,7 +400,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -419,7 +419,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -438,7 +438,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -460,7 +460,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -477,7 +477,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -496,7 +496,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -515,7 +515,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -535,7 +535,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -558,7 +558,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -575,7 +575,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -622,7 +622,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -641,7 +641,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -658,7 +658,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -675,7 +675,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -692,7 +692,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -709,7 +709,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(getWarnings(stats)).toMatchSnapshot("warnings");
@@ -725,7 +725,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -742,7 +742,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(getWarnings(stats)).toMatchSnapshot("warnings");
@@ -761,7 +761,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -784,7 +784,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -835,7 +835,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -855,7 +855,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -872,7 +872,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -902,7 +902,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -921,7 +921,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -941,7 +941,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -958,7 +958,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -982,7 +982,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -999,7 +999,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1030,7 +1030,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1060,7 +1060,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1086,7 +1086,7 @@ describe("loader", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1117,7 +1117,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1134,7 +1134,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1154,7 +1154,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1234,7 +1234,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1251,7 +1251,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1268,7 +1268,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1285,7 +1285,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1302,7 +1302,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1322,7 +1322,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1339,7 +1339,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1356,7 +1356,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1373,7 +1373,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1392,7 +1392,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1411,7 +1411,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1433,7 +1433,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1450,7 +1450,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1469,7 +1469,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1488,7 +1488,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1505,7 +1505,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1552,7 +1552,7 @@ describe("loader", () => {
           });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1569,7 +1569,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1586,7 +1586,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1603,7 +1603,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1620,7 +1620,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1637,7 +1637,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1654,7 +1654,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1674,7 +1674,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1691,7 +1691,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1711,7 +1711,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1728,7 +1728,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1745,7 +1745,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1762,7 +1762,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1792,7 +1792,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1809,7 +1809,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -1839,7 +1839,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
           const logs = [];
 
           for (const [name, value] of stats.compilation.logging) {
@@ -1886,7 +1886,7 @@ describe("loader", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,7 +1,6 @@
 import path from "path";
 import url from "url";
 
-import nodeSass from "node-sass";
 import dartSass from "sass";
 import del from "del";
 
@@ -13,7 +12,7 @@ import {
   getCodeFromSass,
   getCompiler,
   getErrors,
-  getImplementationByName,
+  getImplementationsAndAPI,
   getTestId,
   getWarnings,
 } from "./helpers";
@@ -21,7 +20,7 @@ import {
 jest.setTimeout(60000);
 
 let Fiber;
-const implementations = [nodeSass, dartSass];
+const implementations = getImplementationsAndAPI();
 const syntaxStyles = ["scss", "sass"];
 
 describe("loader", () => {
@@ -39,14 +38,15 @@ describe("loader", () => {
     }
   });
 
-  implementations.forEach((implementation) => {
-    const [implementationName] = implementation.info.split("\t");
+  implementations.forEach((item) => {
+    const { name: implementationName, api, implementation } = item;
 
     syntaxStyles.forEach((syntax) => {
-      it(`should work (${implementationName}) (${syntax})`, async () => {
+      it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -59,7 +59,7 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work (${implementationName}) (${syntax}) with the "memory" cache`, async () => {
+      it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax) with the "memory" cache`, async () => {
         const cache = path.resolve(
           __dirname,
           `./outputs/.cache/sass-loader/${implementationName}/${syntax}`
@@ -69,7 +69,8 @@ describe("loader", () => {
 
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options },
@@ -87,7 +88,7 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work (${implementationName}) (${syntax}) with the "filesystem" cache`, async () => {
+      it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax) with the "filesystem" cache`, async () => {
         const cache = path.resolve(
           __dirname,
           `./outputs/.cache/sass-loader/${implementationName}/${syntax}`
@@ -97,7 +98,8 @@ describe("loader", () => {
 
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options },
@@ -116,10 +118,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with an empty file (${implementationName}) (${syntax})`, async () => {
+      it(`should work with an empty file ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("empty", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -132,10 +135,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should output an understandable error (${implementationName}) (${syntax})`, async () => {
+      it(`should output an understandable error ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("error", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -149,10 +153,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should output an understandable error when the problem in "@import" (${implementationName}) (${syntax})`, async () => {
+      it(`should output an understandable error when the problem in "@import" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("error-import", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -171,10 +176,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should output an understandable error when a file could not be found (${implementationName}) (${syntax})`, async () => {
+      it(`should output an understandable error when a file could not be found ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("error-file-not-found", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -188,10 +194,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should throw an error with a explicit file and a file does not exist (${implementationName}) (${syntax})`, async () => {
+      it(`should throw an error with a explicit file and a file does not exist ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("error-file-not-found-2", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -205,10 +212,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with difference "@import" at-rules (${implementationName}) (${syntax})`, async () => {
+      it(`should work with difference "@import" at-rules ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("imports", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -222,10 +230,11 @@ describe("loader", () => {
       });
 
       // Test for issue: https://github.com/webpack-contrib/sass-loader/issues/32
-      it(`should work with multiple "@import" at-rules (${implementationName}) (${syntax})`, async () => {
+      it(`should work with multiple "@import" at-rules ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("multiple-imports", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -239,10 +248,11 @@ describe("loader", () => {
       });
 
       // Test for issue: https://github.com/webpack-contrib/sass-loader/issues/73
-      it(`should work with "@import" at-rules from other language style (${implementationName}) (${syntax})`, async () => {
+      it(`should work with "@import" at-rules from other language style ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-other-style", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -255,10 +265,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when "@import" at-rules from scoped npm packages (${implementationName}) (${syntax})`, async () => {
+      it(`should work when "@import" at-rules from scoped npm packages ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-from-npm-org-pkg", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -271,10 +282,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when "@import" at-rules with extensions (${implementationName}) (${syntax})`, async () => {
+      it(`should work when "@import" at-rules with extensions ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-with-extension", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -287,10 +299,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when "@import" at-rules starting with "_" (${implementationName}) (${syntax})`, async () => {
+      it(`should work when "@import" at-rules starting with "_" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-with-underscore", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -303,13 +316,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when "@import" at-rules without extensions and do not start with "_" (${implementationName}) (${syntax})`, async () => {
+      it(`should work when "@import" at-rules without extensions and do not start with "_" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "import-without-extension-and-underscore",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -322,14 +336,15 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with multiple "@import" at-rules without quotes (${implementationName}) (${syntax})`, async () => {
+      it(`should work with multiple "@import" at-rules without quotes ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         if (syntax === "scss") {
           return;
         }
 
         const testId = getTestId("import-without-quotes", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -342,10 +357,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "sass" field (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "sass" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-sass-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -358,10 +374,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "style" field (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "style" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-style-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -374,10 +391,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "main" field (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "main" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-main-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -390,10 +408,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "main" field when the "main" value is not in the "mainFields" resolve option (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "main" field when the "main" value is not in the "mainFields" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-main-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options, resolve: { mainFields: [] } },
@@ -408,10 +427,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "main" field when the "main" value already in the "mainFields" resolve option (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "main" field when the "main" value already in the "mainFields" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-main-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options, resolve: { mainFields: ["main", "..."] } },
@@ -426,10 +446,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "custom-sass" field (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "custom-sass" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-custom-sass-field", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: {
@@ -447,10 +468,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "index" file in package (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "index" file in package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-index", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -463,10 +485,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "index" file in package when the "index" value is not in the "mainFiles" resolve option (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "index" file in package when the "index" value is not in the "mainFiles" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-index", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options, resolve: { mainFiles: [] } },
@@ -481,10 +504,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "index" file in package when the "index" value already in the "mainFiles" resolve option (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "index" file in package when the "index" value already in the "mainFiles" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-index", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options, resolve: { mainFiles: ["index", "..."] } },
@@ -499,13 +523,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should prefer "mainFiles" over "mainFields" when the field contains "js" file (${implementationName}) (${syntax})`, async () => {
+      it(`should prefer "mainFiles" over "mainFields" when the field contains "js" file ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "import-prefer-main-files-over-main-fields",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -518,13 +543,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should prefer "mainFiles" with extension over without (${implementationName}) (${syntax})`, async () => {
+      it(`should prefer "mainFiles" with extension over without ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "import-prefer-main-files-with-extension",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             includePaths: ["node_modules/foundation-sites/scss"],
           },
@@ -540,10 +566,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and use the "_index" file in package (${implementationName}) (${syntax})`, async () => {
+      it(`should work and use the "_index" file in package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-_index", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -556,10 +583,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with an alias (${implementationName}) (${syntax})`, async () => {
+      it(`should work with an alias ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-alias", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           resolve: {
@@ -604,10 +632,11 @@ describe("loader", () => {
 
       // Legacy support for CSS imports with node-sass
       // See discussion https://github.com/webpack-contrib/sass-loader/pull/573/files?#r199109203
-      it(`should work and ignore all css "@import" at-rules (${implementationName}) (${syntax})`, async () => {
+      it(`should work and ignore all css "@import" at-rules ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-css", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -620,10 +649,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "bootstrap-sass" package, directly import (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "bootstrap-sass" package, directly import ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-sass", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -636,10 +666,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "bootstrap-sass" package, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "bootstrap-sass" package, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-sass-package", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -652,10 +683,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with "bootstrap" package v4, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with "bootstrap" package v4, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-v4", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -668,10 +700,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with "bootstrap" package v4 without tilde, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with "bootstrap" package v4 without tilde, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-package-v4", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -683,10 +716,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with "bootstrap" package v5, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with "bootstrap" package v5, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-v5", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -699,10 +733,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with "bootstrap" package v5 without tilde, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with "bootstrap" package v5 without tilde, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("bootstrap-package-v5", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -714,10 +749,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "foundation-sites" package, import as a package (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "foundation-sites" package, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("foundation-sites", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             includePaths: ["node_modules/foundation-sites/scss"],
           },
@@ -733,13 +769,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "foundation-sites" package, adjusting CSS output (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "foundation-sites" package, adjusting CSS output ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "foundation-sites-adjusting-css-output",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             includePaths: ["node_modules/foundation-sites/scss"],
           },
@@ -755,10 +792,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work and output the "compressed" outputStyle when "mode" is production (${implementationName}) (${syntax})`, async () => {
+      it(`should work and output the "compressed" outputStyle when "mode" is production ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           mode: "production",
@@ -781,7 +819,7 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should watch firstly in the "includePaths" values (${implementationName}) (${syntax})`, async () => {
+      it(`should watch firstly in the "includePaths" values ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("prefer-include-paths", syntax);
         const options = {
           sassOptions: {
@@ -791,7 +829,8 @@ describe("loader", () => {
               ),
             ],
           },
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -804,13 +843,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should load only sass/scss files for the "mainFiles" (${implementationName}) (${syntax})`, async () => {
+      it(`should load only sass/scss files for the "mainFiles" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "import-package-with-js-and-css-main-files",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -823,10 +863,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should load files with underscore in the name (${implementationName}) (${syntax})`, async () => {
+      it(`should load files with underscore in the name ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-underscore-file", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -839,7 +880,7 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should respect resolving from the "SASS_PATH" environment variable (${implementationName}) (${syntax})`, async () => {
+      it(`should respect resolving from the "SASS_PATH" environment variable ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         process.env.SASS_PATH =
           process.platform === "win32"
             ? `${path.resolve("test", syntax, "sass_path")};${path.resolve(
@@ -855,7 +896,8 @@ describe("loader", () => {
 
         const testId = getTestId("sass_path-env", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -870,10 +912,11 @@ describe("loader", () => {
         delete process.env.SASS_PATH;
       });
 
-      it(`should respect resolving from "process.cwd()" (${implementationName}) (${syntax})`, async () => {
+      it(`should respect resolving from "process.cwd()" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("process-cwd", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -886,13 +929,14 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should respect resolving directory with the "index" file from "process.cwd()"  (${implementationName}) (${syntax})`, async () => {
+      it(`should respect resolving directory with the "index" file from "process.cwd()"  ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId(
           "process-cwd-with-index-file-inside-directory",
           syntax
         );
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -905,10 +949,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with a package with "sass" and "exports" fields (${implementationName}) (${syntax})`, async () => {
+      it(`should work with a package with "sass" and "exports" fields ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-package-with-exports", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -921,10 +966,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should support resolving using the "file" schema (${implementationName}) (${syntax})`, async () => {
+      it(`should support resolving using the "file" schema ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-file-scheme", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options },
@@ -944,10 +990,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should resolve server-relative URLs (${implementationName}) (${syntax})`, async () => {
+      it(`should resolve server-relative URLs ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-absolute-path", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -960,10 +1007,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should resolve absolute paths (${implementationName}) (${syntax})`, async () => {
+      it(`should resolve absolute paths ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-absolute-path", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           additionalData: (content) =>
             content
               .replace(
@@ -990,10 +1038,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should throw an error on ambiguous import (only on "dart-sass") (${implementationName}) (${syntax})`, async () => {
+      it(`should throw an error on ambiguous import (only on "dart-sass") ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-ambiguous", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -1002,10 +1051,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should prefer relative import (${implementationName}) (${syntax})`, async () => {
+      it(`should prefer relative import ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("package-with-same-import", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -1018,10 +1068,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the 'resolve.byDependecy.sass' option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the 'resolve.byDependecy.sass' option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("by-dependency", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, {
           loader: { options },
@@ -1043,10 +1094,11 @@ describe("loader", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should throw an error on circular import (${implementationName}) (${syntax})`, async () => {
+      it(`should throw an error on circular import ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-circular", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -1056,10 +1108,11 @@ describe("loader", () => {
       });
 
       if (implementation === dartSass) {
-        it(`should work (${implementationName}) (${syntax}) with "@charset "UTF-8";"`, async () => {
+        it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax) with "@charset "UTF-8";"`, async () => {
           const testId = getTestId("charset-utf-8", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1072,10 +1125,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work (${implementationName}) (${syntax}) add "@charset "UTF-8";" for non ascii characters`, async () => {
+        it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax) add "@charset "UTF-8";" for non ascii characters`, async () => {
           const testId = getTestId("non-ascii-characters", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1088,10 +1142,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work (${implementationName}) (${syntax}) to disable "@charset "UTF-8";" generation`, async () => {
+        it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax) to disable "@charset "UTF-8";" generation`, async () => {
           const testId = getTestId("charset-utf-8", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
             sassOptions: {
               charset: false,
             },
@@ -1107,10 +1162,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should output an understandable error with a problem in "@use" (${implementationName}) (${syntax})`, async () => {
+        it(`should output an understandable error with a problem in "@use" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("error-use", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1129,10 +1185,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should output an understandable error when a file could not be found using "@use" rule (${implementationName}) (${syntax})`, async () => {
+        it(`should output an understandable error when a file could not be found using "@use" rule ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("error-file-not-found-use", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1148,10 +1205,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should throw an error with a explicit file and a file does not exist using "@use" rule (${implementationName}) (${syntax})`, async () => {
+        it(`should throw an error with a explicit file and a file does not exist using "@use" rule ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("error-file-not-found-use-2", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1167,10 +1225,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with different "@use" at-rules (${implementationName}) (${syntax})`, async () => {
+        it(`should work with different "@use" at-rules ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("uses", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1183,10 +1242,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with "@use" at-rules from other language style (${implementationName}) (${syntax})`, async () => {
+        it(`should work with "@use" at-rules from other language style ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-other-style", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1199,10 +1259,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" at-rules from scoped npm packages (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" at-rules from scoped npm packages ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-from-npm-org-pkg", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1215,10 +1276,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" at-rules with extensions (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" at-rules with extensions ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-with-extension", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1231,10 +1293,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" at-rules starting with "_" (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" at-rules starting with "_" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-with-underscore", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1247,13 +1310,14 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" at-rules without extensions and do not start with "_" (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" at-rules without extensions and do not start with "_" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId(
             "use-without-extension-and-underscore",
             syntax
           );
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1266,10 +1330,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "sass" field (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "sass" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-sass-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1282,10 +1347,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "style" field (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "style" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-style-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1298,10 +1364,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "main" field (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "main" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-main-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1314,10 +1381,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "main" field when the "main" value is not in the "mainFields" resolve option (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "main" field when the "main" value is not in the "mainFields" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-main-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             loader: { options, resolve: { mainFields: [] } },
@@ -1332,10 +1400,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "main" field when the "main" value already in the "mainFields" resolve option (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "main" field when the "main" value already in the "mainFields" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-main-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             loader: { options, resolve: { mainFields: ["main", "..."] } },
@@ -1350,10 +1419,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "custom-sass" field (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "custom-sass" field ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-custom-sass-field", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             loader: {
@@ -1371,10 +1441,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "index" file in package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "index" file in package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-index", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1387,10 +1458,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "index" file in package when the "index" value is not in the "mainFiles" resolve option (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "index" file in package when the "index" value is not in the "mainFiles" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-index", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             loader: { options, resolve: { mainFiles: [] } },
@@ -1405,10 +1477,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" and use the "index" file in package when the "index" value already in the "mainFiles" resolve option (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" and use the "index" file in package when the "index" value already in the "mainFiles" resolve option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-index", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             loader: { options, resolve: { mainFiles: ["index", "..."] } },
@@ -1423,10 +1496,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use"and use the "_index" file in package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use"and use the "_index" file in package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-_index", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1439,10 +1513,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with an alias (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with an alias ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-alias", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, {
             resolve: {
@@ -1485,10 +1560,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with the "bootstrap-sass" package, directly import (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with the "bootstrap-sass" package, directly import ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-sass", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1501,10 +1577,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with the "bootstrap-sass" package, import as a package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with the "bootstrap-sass" package, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-sass-package", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1517,10 +1594,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with "bootstrap" package v4, import as a package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with "bootstrap" package v4, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-v4", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1533,10 +1611,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with "bootstrap" package v4 without tilde, import as a package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with "bootstrap" package v4 without tilde, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-package-v4", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1549,10 +1628,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with "bootstrap" package v5, import as a package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with "bootstrap" package v5, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-v5", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1565,10 +1645,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work when "@use" with "bootstrap" package v5 without tilde, import as a package (${implementationName}) (${syntax})`, async () => {
+        it(`should work when "@use" with "bootstrap" package v5 without tilde, import as a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-bootstrap-package-v5", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1581,10 +1662,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with the "material-components-web" package (${implementationName}) (${syntax})`, async () => {
+        it(`should work with the "material-components-web" package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("import-material-components-web", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
             sassOptions: {
               includePaths: ["node_modules"],
             },
@@ -1600,10 +1682,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with the "material-components-web" package without the "includePaths" option (${implementationName}) (${syntax})`, async () => {
+        it(`should work with the "material-components-web" package without the "includePaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("import-material-components-web", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1616,10 +1699,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with the "material-components-web" package (${implementationName}) (${syntax})`, async () => {
+        it(`should work with the "material-components-web" package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-material-components-web", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
             sassOptions: {
               includePaths: ["node_modules"],
             },
@@ -1635,10 +1719,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should work with the "material-components-web" package without the "includePaths" option (${implementationName}) (${syntax})`, async () => {
+        it(`should work with the "material-components-web" package without the "includePaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-material-components-web", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1651,10 +1736,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should import .import.${syntax} files (${implementationName}) (${syntax})`, async () => {
+        it(`should import .import.${syntax} files ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("import-index-import", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1667,10 +1753,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should import .import.${syntax} files from a package (${implementationName}) (${syntax})`, async () => {
+        it(`should import .import.${syntax} files from a package ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("import-index-import-from-package", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1683,10 +1770,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should not use .import.${syntax} files (${implementationName}) (${syntax})`, async () => {
+        it(`should not use .import.${syntax} files ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-index-import", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1695,10 +1783,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should prefer "${syntax})" over CSS (${implementationName}) (${syntax})`, async () => {
+        it(`should prefer "${syntax})" over CSS ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-dir-with-css", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1714,7 +1803,8 @@ describe("loader", () => {
         it(`should work and output deprecation message (${implementationName})`, async () => {
           const testId = getTestId("deprecation", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1727,10 +1817,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should throw an error on circular use (${implementationName}) (${syntax})`, async () => {
+        it(`should throw an error on circular use ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("use-circular", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1739,10 +1830,11 @@ describe("loader", () => {
           expect(getErrors(stats)).toMatchSnapshot("errors");
         });
 
-        it(`should use webpack logger (${implementationName}) (${syntax})`, async () => {
+        it(`should use webpack logger ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("logging", syntax);
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -1753,10 +1845,10 @@ describe("loader", () => {
           for (const [name, value] of stats.compilation.logging) {
             if (/sass-loader/.test(name)) {
               logs.push(
-                value.map((item) => {
+                value.map((i) => {
                   return {
-                    type: item.type,
-                    args: item.args.map((arg) =>
+                    type: i.type,
+                    args: i.args.map((arg) =>
                       arg
                         .replace(url.pathToFileURL(__dirname), "file:///<cwd>")
                         .replace(/\\/g, "/")
@@ -1774,11 +1866,12 @@ describe("loader", () => {
           expect(logs).toMatchSnapshot("logs");
         });
 
-        it(`should allow to use own logger (${implementationName}) (${syntax})`, async () => {
+        it(`should allow to use own logger ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("logging", syntax);
           const logs = [];
           const options = {
-            implementation: getImplementationByName(implementationName),
+            implementation,
+            api,
             sassOptions: {
               logger: {
                 warn: (message) => {

--- a/test/sass/custom-functions-modern.sass
+++ b/test/sass/custom-functions-modern.sass
@@ -1,0 +1,2 @@
+h1
+  font-size: pow(2, 5) * 1px

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -56,7 +56,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -74,7 +74,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -98,7 +98,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -120,7 +120,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -140,7 +140,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -160,7 +160,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -180,7 +180,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -200,7 +200,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -220,7 +220,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -265,7 +265,7 @@ describe("sassOptions option", () => {
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
           const codeFromBundle = getCodeFromBundle(stats, compiler);
-          const codeFromSass = getCodeFromSass(testId, options);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
           expect(codeFromBundle.css).toBe(codeFromSass.css);
           expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -291,7 +291,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -310,7 +310,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -329,7 +329,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -349,7 +349,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -369,7 +369,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -397,7 +397,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         if (
           implementationName === "dart-sass" &&
@@ -426,7 +426,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         if (
           implementationName === "dart-sass" &&
@@ -455,7 +455,7 @@ describe("sassOptions option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         if (
           api !== "modern" &&
@@ -489,7 +489,7 @@ describe("sassOptions option", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -188,48 +188,48 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("custom-importer", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            importer: customImporter,
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
-
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
-
-      it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("custom-importer", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            importer: [customImporter],
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
-
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
-
       // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
       if (api !== "modern") {
+        it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("custom-importer", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              importer: customImporter,
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+
+        it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("custom-importer", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              importer: [customImporter],
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+
         it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           expect.assertions(4);
 
@@ -345,9 +345,14 @@ describe("sassOptions option", () => {
         const options = {
           implementation,
           api,
-          sassOptions: {
-            indentedSyntax: syntax === "sass",
-          },
+          sassOptions:
+            api === "modern"
+              ? {
+                  syntax: syntax === "sass" ? "indented" : "scss",
+                }
+              : {
+                  indentedSyntax: syntax === "sass",
+                },
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -365,9 +370,8 @@ describe("sassOptions option", () => {
         const options = {
           implementation,
           api,
-          sassOptions: {
-            linefeed: "lf",
-          },
+          // Doesn't supported by modern API
+          sassOptions: api === "modern" ? {} : { linefeed: "lf" },
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -405,6 +409,7 @@ describe("sassOptions option", () => {
         if (
           implementationName === "dart-sass" &&
           semver.satisfies(process.version, ">= 10") &&
+          api !== "modern" &&
           isSupportedFibers()
         ) {
           expect(dartSassSpy.mock.calls[0][0]).toHaveProperty("fiber");

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -509,11 +509,12 @@ describe("sassOptions option", () => {
         });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, {
+        const codeFromSass = await getCodeFromSass(testId, {
           ...options,
-          sassOptions: {
-            outputStyle: "compressed",
-          },
+          sassOptions:
+            api === "modern"
+              ? { style: "compressed" }
+              : { outputStyle: "compressed" },
         });
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -174,7 +174,7 @@ describe("sassOptions option", () => {
           implementation,
           api,
           sassOptions: {
-            functions: customFunctions(implementation),
+            functions: customFunctions(api, implementation),
           },
         };
         const compiler = getCompiler(testId, { loader: { options } });

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -228,29 +228,32 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        expect.assertions(4);
+      // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
+      if (api !== "modern") {
+        it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          expect.assertions(4);
 
-        const testId = getTestId("custom-importer", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            importer(url, prev, done) {
-              expect(this.webpackLoaderContext).toBeDefined();
+          const testId = getTestId("custom-importer", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              importer(url, prev, done) {
+                expect(this.webpackLoaderContext).toBeDefined();
 
-              return done({ contents: ".a { color: red; }" });
+                return done({ contents: ".a { color: red; }" });
+              },
             },
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
 
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
       if (api !== "modern") {
         it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -92,9 +92,7 @@ describe("sassOptions option", () => {
           sassOptions: (loaderContext) => {
             expect(loaderContext).toBeDefined();
 
-            return {
-              indentWidth: 10,
-            };
+            return api === "modern" ? {} : { indentWidth: 10 };
           },
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -254,34 +252,41 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("glob-importer", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            importer: [globImporter()],
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+      if (api !== "modern") {
+        it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("glob-importer", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              importer: [globImporter()],
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
-      it(`should work with the "includePaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+      it(`should work with the "includePaths"/"loadPaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-include-paths", syntax);
         const options = {
           implementation,
           api,
-          sassOptions: {
-            includePaths: [path.resolve(__dirname, syntax, "includePath")],
-          },
+          sassOptions:
+            api === "modern"
+              ? { loadPaths: [path.resolve(__dirname, syntax, "includePath")] }
+              : {
+                  includePaths: [
+                    path.resolve(__dirname, syntax, "includePath"),
+                  ],
+                },
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -299,9 +304,8 @@ describe("sassOptions option", () => {
         const options = {
           implementation,
           api,
-          sassOptions: {
-            indentType: "tab",
-          },
+          // Doesn't supported by modern API
+          sassOptions: api === "modern" ? {} : { indentType: "tab" },
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -319,9 +323,8 @@ describe("sassOptions option", () => {
         const options = {
           implementation,
           api,
-          sassOptions: {
-            indentWidth: 4,
-          },
+          // Doesn't supported by modern API
+          sassOptions: api === "modern" ? {} : { indentWidth: 4 },
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -455,6 +458,7 @@ describe("sassOptions option", () => {
         const codeFromSass = getCodeFromSass(testId, options);
 
         if (
+          api !== "modern" &&
           implementationName === "dart-sass" &&
           semver.satisfies(process.version, ">= 10")
         ) {
@@ -474,9 +478,10 @@ describe("sassOptions option", () => {
         const options = {
           implementation,
           api,
-          sassOptions: {
-            outputStyle: "expanded",
-          },
+          sassOptions:
+            api === "modern"
+              ? { style: "expanded" }
+              : { outputStyle: "expanded" },
         };
         const compiler = getCompiler(testId, {
           mode: "production",

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -2,7 +2,6 @@ import path from "path";
 
 import globImporter from "node-sass-glob-importer";
 import semver from "semver";
-import nodeSass from "node-sass";
 import dartSass from "sass";
 
 import { isSupportedFibers } from "../src/utils";
@@ -14,16 +13,16 @@ import {
   getCodeFromBundle,
   getCodeFromSass,
   getErrors,
-  getImplementationByName,
   getTestId,
   getWarnings,
   getCompiler,
+  getImplementationsAndAPI,
 } from "./helpers";
 
 jest.setTimeout(30000);
 
 let Fiber;
-const implementations = [nodeSass, dartSass];
+const implementations = getImplementationsAndAPI();
 const syntaxStyles = ["scss", "sass"];
 
 describe("sassOptions option", () => {
@@ -41,14 +40,15 @@ describe("sassOptions option", () => {
     }
   });
 
-  implementations.forEach((implementation) => {
-    const [implementationName] = implementation.info.split("\t");
+  implementations.forEach((item) => {
+    const { name: implementationName, api, implementation } = item;
 
     syntaxStyles.forEach((syntax) => {
-      it(`should work when the option like "Object" (${implementationName}) (${syntax})`, async () => {
+      it(`should work when the option like "Object" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             indentWidth: 10,
           },
@@ -64,10 +64,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when the option is empty "Object" (${implementationName}) (${syntax})`, async () => {
+      it(`should work when the option is empty "Object" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {},
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -81,12 +82,13 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when the option like "Function" (${implementationName}) (${syntax})`, async () => {
+      it(`should work when the option like "Function" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(6);
 
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: (loaderContext) => {
             expect(loaderContext).toBeDefined();
 
@@ -106,12 +108,13 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work when the option like "Function" and never return (${implementationName}) (${syntax})`, async () => {
+      it(`should work when the option like "Function" and never return ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(6);
 
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: (loaderContext) => {
             expect(loaderContext).toBeDefined();
           },
@@ -127,10 +130,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should ignore the "file" option (${implementationName}) (${syntax})`, async () => {
+      it(`should ignore the "file" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             file: "test",
           },
@@ -146,10 +150,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should ignore the "data" option (${implementationName}) (${syntax})`, async () => {
+      it(`should ignore the "data" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             data: "test",
           },
@@ -165,10 +170,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "functions" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "functions" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("custom-functions", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             functions: customFunctions(implementation),
           },
@@ -184,10 +190,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a single function option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("custom-importer", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             importer: customImporter,
           },
@@ -203,10 +210,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a array of functions option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("custom-importer", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             importer: [customImporter],
           },
@@ -222,12 +230,13 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a single function option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(4);
 
         const testId = getTestId("custom-importer", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             importer(url, prev, done) {
               expect(this.webpackLoaderContext).toBeDefined();
@@ -245,10 +254,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "importer" as a array of functions option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("glob-importer", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             importer: [globImporter()],
           },
@@ -264,10 +274,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "includePaths" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "includePaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("import-include-paths", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             includePaths: [path.resolve(__dirname, syntax, "includePath")],
           },
@@ -283,10 +294,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "indentType" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "indentType" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             indentType: "tab",
           },
@@ -302,10 +314,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "indentWidth" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "indentWidth" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             indentWidth: 4,
           },
@@ -321,10 +334,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "indentedSyntax" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "indentedSyntax" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             indentedSyntax: syntax === "sass",
           },
@@ -340,10 +354,11 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "linefeed" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "linefeed" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             linefeed: "lf",
           },
@@ -359,11 +374,12 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "fiber" option (${implementationName}) (${syntax})`, async () => {
+      it(`should work with the "fiber" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const dartSassSpy = jest.spyOn(dartSass, "render");
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {},
         };
 
@@ -396,11 +412,12 @@ describe("sassOptions option", () => {
         dartSassSpy.mockRestore();
       });
 
-      it(`should use the "fibers" package if it is possible (${implementationName}) (${syntax})`, async () => {
+      it(`should use the "fibers" package if it is possible ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const dartSassSpy = jest.spyOn(dartSass, "render");
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {},
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -424,11 +441,12 @@ describe("sassOptions option", () => {
         dartSassSpy.mockRestore();
       });
 
-      it(`should don't use the "fibers" package when the "fiber" option is "false" (${implementationName}) (${syntax})`, async () => {
+      it(`should don't use the "fibers" package when the "fiber" option is "false" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const dartSassSpy = jest.spyOn(dartSass, "render");
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: { fiber: false },
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -451,10 +469,11 @@ describe("sassOptions option", () => {
         dartSassSpy.mockRestore();
       });
 
-      it(`should respect the "outputStyle" option (${implementationName}) (${syntax})`, async () => {
+      it(`should respect the "outputStyle" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sassOptions: {
             outputStyle: "expanded",
           },
@@ -473,11 +492,9 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should use "compressed" output style in the "production" mode (${implementationName}) (${syntax})`, async () => {
+      it(`should use "compressed" output style in the "production" mode ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-        };
+        const options = { implementation, api };
         const compiler = getCompiler(testId, {
           mode: "production",
           loader: { options },

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -168,25 +168,35 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "functions" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("custom-functions", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            functions: customFunctions(api, implementation),
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
+      const needSkip =
+        (implementationName === "sass-embedded" && api === "old") ||
+        (implementationName === "dart-sass" && api === "modern");
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+      if (!needSkip) {
+        it(`should work with the "functions" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId(
+            api === "modern" ? "custom-functions-modern" : "custom-functions",
+            syntax
+          );
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              functions: customFunctions(api, implementation),
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
       // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
       if (api !== "modern") {

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -128,25 +128,47 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should ignore the "file" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {
-            file: "test",
-          },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      if (api === "modern") {
+        it(`should ignore the "url" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              url: "test",
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      } else {
+        it(`should ignore the "file" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              file: "test",
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
       it(`should ignore the "data" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
@@ -199,7 +221,7 @@ describe("sassOptions option", () => {
       }
 
       // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
-      if (api !== "modern") {
+      if (api !== "modern" && implementationName !== "sass-embedded") {
         it(`should work with the "importer" as a single function option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("custom-importer", syntax);
           const options = {
@@ -265,7 +287,7 @@ describe("sassOptions option", () => {
         });
       }
 
-      if (api !== "modern") {
+      if (api !== "modern" && implementationName !== "sass-embedded") {
         it(`should work with the "importer" as a array of functions option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("glob-importer", syntax);
           const options = {
@@ -287,70 +309,71 @@ describe("sassOptions option", () => {
         });
       }
 
-      it(`should work with the "includePaths"/"loadPaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("import-include-paths", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions:
-            api === "modern"
-              ? { loadPaths: [path.resolve(__dirname, syntax, "includePath")] }
-              : {
-                  includePaths: [
-                    path.resolve(__dirname, syntax, "includePath"),
-                  ],
-                },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
+      if (api !== "modern" && implementationName !== "sass-embedded") {
+        it(`should work with the "includePaths" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("import-include-paths", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {
+              includePaths: [path.resolve(__dirname, syntax, "includePath")],
+            },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
-      it(`should work with the "indentType" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          // Doesn't supported by modern API
-          sassOptions: api === "modern" ? {} : { indentType: "tab" },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      if (api !== "modern") {
+        it(`should work with the "indentType" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: { indentType: "tab" },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
-      it(`should work with the "indentWidth" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          // Doesn't supported by modern API
-          sassOptions: api === "modern" ? {} : { indentWidth: 4 },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      if (api !== "modern") {
+        it(`should work with the "indentWidth" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            // Doesn't supported by modern API
+            sassOptions: { indentWidth: 4 },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
-      it(`should work with the "indentedSyntax" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+      it(`should work with the "indentedSyntax"/"syntax" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
           implementation,
@@ -375,123 +398,125 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should work with the "linefeed" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          // Doesn't supported by modern API
-          sassOptions: api === "modern" ? {} : { linefeed: "lf" },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+      if (api !== "modern") {
+        it(`should work with the "linefeed" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            // Doesn't supported by modern API
+            sassOptions: api === "modern" ? {} : { linefeed: "lf" },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
-      });
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
 
-      it(`should work with the "fiber" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const dartSassSpy = jest.spyOn(dartSass, "render");
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {},
-        };
+      if (api !== "modern") {
+        it(`should work with the "fiber" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const dartSassSpy = jest.spyOn(dartSass, "render");
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {},
+          };
 
-        if (
-          implementationName === "dart-sass" &&
-          semver.satisfies(process.version, ">= 10")
-        ) {
-          // eslint-disable-next-line global-require
-          options.sassOptions.fiber = Fiber;
-        }
+          if (
+            implementationName === "dart-sass" &&
+            semver.satisfies(process.version, ">= 10")
+          ) {
+            // eslint-disable-next-line global-require
+            options.sassOptions.fiber = Fiber;
+          }
 
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        if (
-          implementationName === "dart-sass" &&
-          semver.satisfies(process.version, ">= 10") &&
-          api !== "modern" &&
-          isSupportedFibers()
-        ) {
-          expect(dartSassSpy.mock.calls[0][0]).toHaveProperty("fiber");
-        }
+          if (
+            implementationName === "dart-sass" &&
+            semver.satisfies(process.version, ">= 10") &&
+            isSupportedFibers()
+          ) {
+            expect(dartSassSpy.mock.calls[0][0]).toHaveProperty("fiber");
+          }
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
 
-        dartSassSpy.mockRestore();
-      });
+          dartSassSpy.mockRestore();
+        });
 
-      it(`should use the "fibers" package if it is possible ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const dartSassSpy = jest.spyOn(dartSass, "render");
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: {},
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+        it(`should use the "fibers" package if it is possible ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const dartSassSpy = jest.spyOn(dartSass, "render");
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: {},
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        if (
-          implementationName === "dart-sass" &&
-          semver.satisfies(process.version, ">= 10") &&
-          isSupportedFibers()
-        ) {
-          expect(dartSassSpy.mock.calls[0][0]).toHaveProperty("fiber");
-        }
+          if (
+            implementationName === "dart-sass" &&
+            semver.satisfies(process.version, ">= 10") &&
+            isSupportedFibers()
+          ) {
+            expect(dartSassSpy.mock.calls[0][0]).toHaveProperty("fiber");
+          }
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
 
-        dartSassSpy.mockRestore();
-      });
+          dartSassSpy.mockRestore();
+        });
 
-      it(`should don't use the "fibers" package when the "fiber" option is "false" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
-        const dartSassSpy = jest.spyOn(dartSass, "render");
-        const testId = getTestId("language", syntax);
-        const options = {
-          implementation,
-          api,
-          sassOptions: { fiber: false },
-        };
-        const compiler = getCompiler(testId, { loader: { options } });
-        const stats = await compile(compiler);
-        const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = await getCodeFromSass(testId, options);
+        it(`should don't use the "fibers" package when the "fiber" option is "false" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const dartSassSpy = jest.spyOn(dartSass, "render");
+          const testId = getTestId("language", syntax);
+          const options = {
+            implementation,
+            api,
+            sassOptions: { fiber: false },
+          };
+          const compiler = getCompiler(testId, { loader: { options } });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options);
 
-        if (
-          api !== "modern" &&
-          implementationName === "dart-sass" &&
-          semver.satisfies(process.version, ">= 10")
-        ) {
-          expect(dartSassSpy.mock.calls[0][0]).not.toHaveProperty("fiber");
-        }
+          if (
+            implementationName === "dart-sass" &&
+            semver.satisfies(process.version, ">= 10")
+          ) {
+            expect(dartSassSpy.mock.calls[0][0]).not.toHaveProperty("fiber");
+          }
 
-        expect(codeFromBundle.css).toBe(codeFromSass.css);
-        expect(codeFromBundle.css).toMatchSnapshot("css");
-        expect(getWarnings(stats)).toMatchSnapshot("warnings");
-        expect(getErrors(stats)).toMatchSnapshot("errors");
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
 
-        dartSassSpy.mockRestore();
-      });
+          dartSassSpy.mockRestore();
+        });
+      }
 
-      it(`should respect the "outputStyle" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+      it(`should respect the "outputStyle"/"style" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
           implementation,

--- a/test/scss/custom-functions-modern.scss
+++ b/test/scss/custom-functions-modern.scss
@@ -1,0 +1,3 @@
+h1 {
+  font-size: pow(2, 5) * 1px;
+}

--- a/test/sourceMap-options.test.js
+++ b/test/sourceMap-options.test.js
@@ -1,9 +1,6 @@
 import fs from "fs";
 import path from "path";
 
-import nodeSass from "node-sass";
-import dartSass from "sass";
-
 import { isSupportedFibers } from "../src/utils";
 
 import {
@@ -11,13 +8,13 @@ import {
   getCodeFromBundle,
   getCompiler,
   getErrors,
-  getImplementationByName,
+  getImplementationsAndAPI,
   getTestId,
   getWarnings,
 } from "./helpers";
 
 let Fiber;
-const implementations = [nodeSass, dartSass];
+const implementations = getImplementationsAndAPI();
 const syntaxStyles = ["scss", "sass"];
 
 describe("sourceMap option", () => {
@@ -35,17 +32,15 @@ describe("sourceMap option", () => {
     }
   });
 
-  implementations.forEach((implementation) => {
+  implementations.forEach((item) => {
     syntaxStyles.forEach((syntax) => {
-      const [implementationName] = implementation.info.split("\t");
+      const { name: implementationName, api, implementation } = item;
 
-      it(`should generate source maps when value is not specified and the "devtool" option has "source-map" value (${implementationName}) (${syntax})`, async () => {
+      it(`should generate source maps when value is not specified and the "devtool" option has "source-map" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(10);
 
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-        };
+        const options = { implementation, api };
         const compiler = getCompiler(testId, {
           devtool: "source-map",
           loader: { options },
@@ -72,14 +67,11 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should generate source maps when value has "true" value and the "devtool" option has "source-map" value (${implementationName}) (${syntax})`, async () => {
+      it(`should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(10);
 
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          sourceMap: true,
-        };
+        const options = { implementation, api, sourceMap: true };
         const compiler = getCompiler(testId, {
           devtool: "source-map",
           loader: { options },
@@ -106,14 +98,11 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should generate source maps when value has "true" value and the "devtool" option has "false" value (${implementationName}) (${syntax})`, async () => {
+      it(`should generate source maps when value has "true" value and the "devtool" option has "false" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(10);
 
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          sourceMap: true,
-        };
+        const options = { implementation, api, sourceMap: true };
         const compiler = getCompiler(testId, {
           devtool: false,
           loader: { options },
@@ -140,12 +129,13 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value (${implementationName}) (${syntax})`, async () => {
+      it(`should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         expect.assertions(8);
 
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           sourceMap: false,
           sassOptions: {
             sourceMap: true,
@@ -180,11 +170,9 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should not generate source maps when value is not specified and the "devtool" option has "false" value (${implementationName}) (${syntax})`, async () => {
+      it(`should not generate source maps when value is not specified and the "devtool" option has "false" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-        };
+        const options = { implementation, api };
         const compiler = getCompiler(testId, {
           devtool: false,
           loader: { options },
@@ -198,12 +186,9 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should not generate source maps when value has "false" value and the "devtool" option has "source-map" value (${implementationName}) (${syntax})`, async () => {
+      it(`should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          sourceMap: false,
-        };
+        const options = { implementation, api, sourceMap: false };
         const compiler = getCompiler(testId, {
           devtool: "source-map",
           loader: { options },
@@ -217,12 +202,9 @@ describe("sourceMap option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`should not generate source maps when value has "false" value and the "devtool" option has "false" value (${implementationName}) (${syntax})`, async () => {
+      it(`should not generate source maps when value has "false" value and the "devtool" option has "false" value ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
-        const options = {
-          implementation: getImplementationByName(implementationName),
-          sourceMap: false,
-        };
+        const options = { implementation, api, sourceMap: false };
         const compiler = getCompiler(testId, {
           devtool: false,
           loader: { options },

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -13,6 +13,7 @@ describe("validate options", () => {
   beforeAll(async () => {
     if (isSupportedFibers()) {
       const { default: fibers } = await import("fibers");
+
       Fiber = fibers;
     }
   });

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -28,7 +28,13 @@ describe("validate options", () => {
   const tests = {
     implementation: {
       // eslint-disable-next-line global-require
-      success: [require("sass"), require("node-sass"), "sass", "node-sass"],
+      success: [
+        require("sass"),
+        require("node-sass"),
+        require("sass-embedded"),
+        "sass",
+        "node-sass",
+      ],
       failure: [true, () => {}],
     },
     sassOptions: {

--- a/test/warnRuleAsWarning.test.js
+++ b/test/warnRuleAsWarning.test.js
@@ -48,7 +48,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
         const logs = [];
 
         for (const [name, value] of stats.compilation.logging) {
@@ -85,7 +85,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
         const logs = [];
 
         for (const [name, value] of stats.compilation.logging) {
@@ -122,7 +122,7 @@ describe("loader", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
         const logs = [];
 
         for (const [name, value] of stats.compilation.logging) {

--- a/test/warnRuleAsWarning.test.js
+++ b/test/warnRuleAsWarning.test.js
@@ -1,7 +1,5 @@
 import url from "url";
 
-import dartSass from "sass";
-
 import { isSupportedFibers } from "../src/utils";
 
 import {
@@ -10,7 +8,7 @@ import {
   getCodeFromSass,
   getCompiler,
   getErrors,
-  getImplementationByName,
+  getImplementationsAndAPI,
   getTestId,
   getWarnings,
 } from "./helpers";
@@ -18,13 +16,14 @@ import {
 jest.setTimeout(60000);
 
 let Fiber;
-const implementations = [dartSass];
+const implementations = getImplementationsAndAPI();
 const syntaxStyles = ["scss", "sass"];
 
 describe("loader", () => {
   beforeAll(async () => {
     if (isSupportedFibers()) {
       const { default: fibers } = await import("fibers");
+
       Fiber = fibers;
     }
   });
@@ -36,14 +35,15 @@ describe("loader", () => {
     }
   });
 
-  implementations.forEach((implementation) => {
-    const [implementationName] = implementation.info.split("\t");
+  implementations.forEach((item) => {
+    const { name: implementationName, api, implementation } = item;
 
     syntaxStyles.forEach((syntax) => {
-      it(`should not emit warning by default (${implementationName}) (${syntax})`, async () => {
+      it(`should not emit warning by default ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("logging", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -54,10 +54,10 @@ describe("loader", () => {
         for (const [name, value] of stats.compilation.logging) {
           if (/sass-loader/.test(name)) {
             logs.push(
-              value.map((item) => {
+              value.map((i) => {
                 return {
-                  type: item.type,
-                  args: item.args.map((arg) =>
+                  type: i.type,
+                  args: i.args.map((arg) =>
                     arg
                       .replace(url.pathToFileURL(__dirname), "file:///<cwd>")
                       .replace(/\\/g, "/")
@@ -75,10 +75,11 @@ describe("loader", () => {
         expect(logs).toMatchSnapshot("logs");
       });
 
-      it(`should not emit warning when 'false' used (${implementationName}) (${syntax})`, async () => {
+      it(`should not emit warning when 'false' used ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("logging", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           warnRuleAsWarning: false,
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -90,10 +91,10 @@ describe("loader", () => {
         for (const [name, value] of stats.compilation.logging) {
           if (/sass-loader/.test(name)) {
             logs.push(
-              value.map((item) => {
+              value.map((i) => {
                 return {
-                  type: item.type,
-                  args: item.args.map((arg) =>
+                  type: i.type,
+                  args: i.args.map((arg) =>
                     arg
                       .replace(url.pathToFileURL(__dirname), "file:///<cwd>")
                       .replace(/\\/g, "/")
@@ -111,10 +112,11 @@ describe("loader", () => {
         expect(logs).toMatchSnapshot("logs");
       });
 
-      it(`should not emit warning when 'true' used (${implementationName}) (${syntax})`, async () => {
+      it(`should not emit warning when 'true' used ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("logging", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
           warnRuleAsWarning: true,
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -126,10 +128,10 @@ describe("loader", () => {
         for (const [name, value] of stats.compilation.logging) {
           if (/sass-loader/.test(name)) {
             logs.push(
-              value.map((item) => {
+              value.map((i) => {
                 return {
-                  type: item.type,
-                  args: item.args.map((arg) =>
+                  type: i.type,
+                  args: i.args.map((arg) =>
                     arg
                       .replace(url.pathToFileURL(__dirname), "file:///<cwd>")
                       .replace(/\\/g, "/")

--- a/test/webpackImporter-options.test.js
+++ b/test/webpackImporter-options.test.js
@@ -1,6 +1,3 @@
-import nodeSass from "node-sass";
-import dartSass from "sass";
-
 import { isSupportedFibers } from "../src/utils";
 
 import {
@@ -9,13 +6,13 @@ import {
   getCodeFromSass,
   getCompiler,
   getErrors,
-  getImplementationByName,
+  getImplementationsAndAPI,
   getTestId,
   getWarnings,
 } from "./helpers";
 
 let Fiber;
-const implementations = [nodeSass, dartSass];
+const implementations = getImplementationsAndAPI();
 const syntaxStyles = ["scss", "sass"];
 
 describe("webpackImporter option", () => {
@@ -33,14 +30,15 @@ describe("webpackImporter option", () => {
     }
   });
 
-  implementations.forEach((implementation) => {
+  implementations.forEach((item) => {
     syntaxStyles.forEach((syntax) => {
-      const [implementationName] = implementation.info.split("\t");
+      const { name: implementationName, api, implementation } = item;
 
-      it(`not specify (${implementationName}) (${syntax})`, async () => {
+      it(`not specify ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
-          implementation: getImplementationByName(implementationName),
+          implementation,
+          api,
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -53,11 +51,12 @@ describe("webpackImporter option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`false (${implementationName}) (${syntax})`, async () => {
+      it(`false ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
+          implementation,
+          api,
           webpackImporter: false,
-          implementation: getImplementationByName(implementationName),
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
@@ -70,11 +69,12 @@ describe("webpackImporter option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      it(`true (${implementationName}) (${syntax})`, async () => {
+      it(`true ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
+          implementation,
+          api,
           webpackImporter: true,
-          implementation: getImplementationByName(implementationName),
         };
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);

--- a/test/webpackImporter-options.test.js
+++ b/test/webpackImporter-options.test.js
@@ -34,6 +34,11 @@ describe("webpackImporter option", () => {
     syntaxStyles.forEach((syntax) => {
       const { name: implementationName, api, implementation } = item;
 
+      // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
+      if (api === "modern") {
+        return;
+      }
+
       it(`not specify ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
         const testId = getTestId("language", syntax);
         const options = {
@@ -43,7 +48,7 @@ describe("webpackImporter option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -61,7 +66,7 @@ describe("webpackImporter option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");
@@ -79,7 +84,7 @@ describe("webpackImporter option", () => {
         const compiler = getCompiler(testId, { loader: { options } });
         const stats = await compile(compiler);
         const codeFromBundle = getCodeFromBundle(stats, compiler);
-        const codeFromSass = getCodeFromSass(testId, options);
+        const codeFromSass = await getCodeFromSass(testId, options);
 
         expect(codeFromBundle.css).toBe(codeFromSass.css);
         expect(codeFromBundle.css).toMatchSnapshot("css");


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

https://github.com/webpack-contrib/sass-loader/issues/774

Added:
- added `api: "modern"` and `api: "old"`
- added `sass-embedded` support

### Breaking Changes

No

### Additional Info

- default importer is not implemented for modern API
- no ability to get webpack loader context in importers