### PR TITLE
docs(readme): update types

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Thankfully there are a two solutions to this problem:
 
 Type: 
 ```ts
-object | string
+type implementation = object | string
 ```
 Default: `sass`
 
@@ -304,7 +304,7 @@ module.exports = {
 
 Type: 
 ```ts
-object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object 
+type sassOptions = object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object 
 ```
 Default: defaults values for Sass implementation
 
@@ -402,7 +402,7 @@ module.exports = {
 
 Type: 
 ```ts 
-boolean
+type sourceMap = boolean
 ```
 Default: depends on the `compiler.devtool` value
 
@@ -477,7 +477,7 @@ module.exports = {
 
 Type: 
 ```ts
-string | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => string
+type additionalData = string | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => string
 ```
 
 Default: `undefined`
@@ -585,7 +585,7 @@ module.exports = {
 
 Type: 
 ```ts
-boolean
+type webpackImporter = boolean
 ```
 Default: `true`
 
@@ -622,7 +622,7 @@ module.exports = {
 
 Type: 
 ```ts
-boolean
+type warnRuleAsWarning = boolean
 ```
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ Thankfully there are a two solutions to this problem:
 
 |                     Name                      |         Type         |                 Default                 | Description                                                       |
 | :-------------------------------------------: | :------------------: | :-------------------------------------: | :---------------------------------------------------------------- |
-|    **[`implementation`](#implementation)**    |  `{Object\|String}`  |                 `sass`                  | Setup Sass implementation to use.                                 |
-|       **[`sassOptions`](#sassoptions)**       | `{Object\|Function}` | defaults values for Sass implementation | Options for Sass.                                                 |
-|         **[`sourceMap`](#sourcemap)**         |     `{Boolean}`      |           `compiler.devtool`            | Enables/Disables generation of source maps.                       |
-|    **[`additionalData`](#additionaldata)**    | `{String\|Function}` |               `undefined`               | Prepends/Appends `Sass`/`SCSS` code before the actual entry file. |
-|   **[`webpackImporter`](#webpackimporter)**   |     `{Boolean}`      |                 `true`                  | Enables/Disables the default Webpack importer.                    |
-| **[`warnRuleAsWarning`](#warnruleaswarning)** |     `{Boolean}`      |                 `false`                 | Treats the `@warn` rule as a webpack warning.                     |
+|    **[`implementation`](#implementation)**    |  `{object\|string}`  |                 `sass`                  | Setup Sass implementation to use.                                 |
+|       **[`sassOptions`](#sassoptions)**       | `{object\| (content: string \| Buffer, loaderContext: LoaderContext, meta: any) => object }` | defaults values for Sass implementation | Options for Sass.                                                 |
+|         **[`sourceMap`](#sourcemap)**         |     `{object}`      |           `compiler.devtool`            | Enables/Disables generation of source maps.                       |
+|    **[`additionalData`](#additionaldata)**    | `{string \| (content: string \| Buffer , loaderContext: LoaderContext, meta: any) => string}` |               `undefined`               | Prepends/Appends `Sass`/`SCSS` code before the actual entry file. |
+|   **[`webpackImporter`](#webpackimporter)**   |     `{boolean}`      |                 `true`                  | Enables/Disables the default Webpack importer.                    |
+| **[`warnRuleAsWarning`](#warnruleaswarning)** |     `{boolean}`      |                 `false`                 | Treats the `@warn` rule as a webpack warning.                     |
 
 ### `implementation`
 
-Type: `Object | String`
+Type: `object | string`
 Default: `sass`
 
 The special `implementation` option determines which implementation of Sass to use.
@@ -169,7 +169,7 @@ In order to avoid this situation you can use the `implementation` option.
 
 The `implementation` options either accepts `sass` (`Dart Sass`) or `node-sass` as a module.
 
-#### Object
+#### object
 
 For example, to use Dart Sass, you'd pass:
 
@@ -196,7 +196,7 @@ module.exports = {
 };
 ```
 
-#### String
+#### string
 
 For example, to use Dart Sass, you'd pass:
 
@@ -302,7 +302,7 @@ module.exports = {
 
 ### `sassOptions`
 
-Type: `Object|Function`
+Type: `object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object `
 Default: defaults values for Sass implementation
 
 Options for [Dart Sass](http://sass-lang.com/dart-sass) or [Node Sass](https://github.com/sass/node-sass) implementation.
@@ -324,7 +324,7 @@ Please consult documentation before using them:
 - [Dart Sass documentation](https://github.com/sass/dart-sass#javascript-api) for all available `sass` options.
 - [Node Sass documentation](https://github.com/sass/node-sass/#options) for all available `node-sass` options.
 
-#### `Object`
+#### `object`
 
 Use and object for the Sass implementation setup.
 
@@ -355,7 +355,7 @@ module.exports = {
 };
 ```
 
-#### `Function`
+#### `function`
 
 Allows to setup the Sass implementation by setting different options based on the loader context.
 
@@ -397,7 +397,7 @@ module.exports = {
 
 ### `sourceMap`
 
-Type: `Boolean`
+Type: `boolean`
 Default: depends on the `compiler.devtool` value
 
 Enables/Disables generation of source maps.
@@ -469,7 +469,7 @@ module.exports = {
 
 ### `additionalData`
 
-Type: `String|Function`
+Type: `string | (content: string|Buffer , loaderContext: LoaderContext, meta: any) => string`
 Default: `undefined`
 
 Prepends `Sass`/`SCSS` code before the actual entry file.
@@ -477,7 +477,7 @@ In this case, the `sass-loader` will not override the `data` option but just **p
 
 This is especially useful when some of your Sass variables depend on the environment:
 
-#### `String`
+#### `string`
 
 ```js
 module.exports = {
@@ -501,7 +501,7 @@ module.exports = {
 };
 ```
 
-#### `Function`
+#### `function`
 
 ##### Sync
 
@@ -573,7 +573,7 @@ module.exports = {
 
 ### `webpackImporter`
 
-Type: `Boolean`
+Type: `boolean`
 Default: `true`
 
 Enables/Disables the default Webpack importer.
@@ -607,7 +607,7 @@ module.exports = {
 
 ### `warnRuleAsWarning`
 
-Type: `Boolean`
+Type: `boolean`
 Default: `false`
 
 Treats the `@warn` rule as a webpack warning.

--- a/README.md
+++ b/README.md
@@ -118,19 +118,19 @@ Thankfully there are a two solutions to this problem:
 - Library authors usually provide a variable to modify the asset path. [bootstrap-sass](https://github.com/twbs/bootstrap-sass) for example has an `$icon-font-path`.
 
 ## Options
-
-|                     Name                      |         Type         |                 Default                 | Description                                                       |
-| :-------------------------------------------: | :------------------: | :-------------------------------------: | :---------------------------------------------------------------- |
-|    **[`implementation`](#implementation)**    |  `{object\|string}`  |                 `sass`                  | Setup Sass implementation to use.                                 |
-|       **[`sassOptions`](#sassoptions)**       | `{object\| (content: string \| Buffer, loaderContext: LoaderContext, meta: any) => object }` | defaults values for Sass implementation | Options for Sass.                                                 |
-|         **[`sourceMap`](#sourcemap)**         |     `{object}`      |           `compiler.devtool`            | Enables/Disables generation of source maps.                       |
-|    **[`additionalData`](#additionaldata)**    | `{string \| (content: string \| Buffer , loaderContext: LoaderContext, meta: any) => string}` |               `undefined`               | Prepends/Appends `Sass`/`SCSS` code before the actual entry file. |
-|   **[`webpackImporter`](#webpackimporter)**   |     `{boolean}`      |                 `true`                  | Enables/Disables the default Webpack importer.                    |
-| **[`warnRuleAsWarning`](#warnruleaswarning)** |     `{boolean}`      |                 `false`                 | Treats the `@warn` rule as a webpack warning.                     |
-
+- **[`implementation`](#implementation)**
+- **[`sassOptions`](#sassoptions)** 
+- **[`sourceMap`](#sourcemap)**  
+- **[`additionalData`](#additionaldata)**    
+- **[`webpackImporter`](#webpackimporter)**
+- **[`warnRuleAsWarning`](#warnruleaswarning)** 
+ 
 ### `implementation`
 
-Type: `object | string`
+Type: 
+```ts
+object | string
+```
 Default: `sass`
 
 The special `implementation` option determines which implementation of Sass to use.
@@ -169,7 +169,7 @@ In order to avoid this situation you can use the `implementation` option.
 
 The `implementation` options either accepts `sass` (`Dart Sass`) or `node-sass` as a module.
 
-#### object
+#### `object`
 
 For example, to use Dart Sass, you'd pass:
 
@@ -196,7 +196,7 @@ module.exports = {
 };
 ```
 
-#### string
+#### `string`
 
 For example, to use Dart Sass, you'd pass:
 
@@ -302,7 +302,10 @@ module.exports = {
 
 ### `sassOptions`
 
-Type: `object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object `
+Type: 
+```ts
+object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object 
+```
 Default: defaults values for Sass implementation
 
 Options for [Dart Sass](http://sass-lang.com/dart-sass) or [Node Sass](https://github.com/sass/node-sass) implementation.
@@ -397,7 +400,10 @@ module.exports = {
 
 ### `sourceMap`
 
-Type: `boolean`
+Type: 
+```ts 
+boolean
+```
 Default: depends on the `compiler.devtool` value
 
 Enables/Disables generation of source maps.
@@ -469,7 +475,11 @@ module.exports = {
 
 ### `additionalData`
 
-Type: `string | (content: string|Buffer , loaderContext: LoaderContext, meta: any) => string`
+Type: 
+```ts
+string | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => string
+```
+
 Default: `undefined`
 
 Prepends `Sass`/`SCSS` code before the actual entry file.
@@ -573,7 +583,10 @@ module.exports = {
 
 ### `webpackImporter`
 
-Type: `boolean`
+Type: 
+```ts
+boolean
+```
 Default: `true`
 
 Enables/Disables the default Webpack importer.
@@ -607,7 +620,10 @@ module.exports = {
 
 ### `warnRuleAsWarning`
 
-Type: `boolean`
+Type: 
+```ts
+boolean
+```
 Default: `false`
 
 Treats the `@warn` rule as a webpack warning.

--- a/README.md
+++ b/README.md
@@ -118,19 +118,22 @@ Thankfully there are a two solutions to this problem:
 - Library authors usually provide a variable to modify the asset path. [bootstrap-sass](https://github.com/twbs/bootstrap-sass) for example has an `$icon-font-path`.
 
 ## Options
+
 - **[`implementation`](#implementation)**
-- **[`sassOptions`](#sassoptions)** 
-- **[`sourceMap`](#sourcemap)**  
-- **[`additionalData`](#additionaldata)**    
+- **[`sassOptions`](#sassoptions)**
+- **[`sourceMap`](#sourcemap)**
+- **[`additionalData`](#additionaldata)**
 - **[`webpackImporter`](#webpackimporter)**
-- **[`warnRuleAsWarning`](#warnruleaswarning)** 
- 
+- **[`warnRuleAsWarning`](#warnruleaswarning)**
+
 ### `implementation`
 
-Type: 
+Type:
+
 ```ts
-type implementation = object | string
+type implementation = object | string;
 ```
+
 Default: `sass`
 
 The special `implementation` option determines which implementation of Sass to use.
@@ -302,10 +305,12 @@ module.exports = {
 
 ### `sassOptions`
 
-Type: 
+Type:
+
 ```ts
-type sassOptions = object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object 
+type sassOptions = object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object
 ```
+
 Default: defaults values for Sass implementation
 
 Options for [Dart Sass](http://sass-lang.com/dart-sass) or [Node Sass](https://github.com/sass/node-sass) implementation.
@@ -400,10 +405,12 @@ module.exports = {
 
 ### `sourceMap`
 
-Type: 
-```ts 
-type sourceMap = boolean
+Type:
+
+```ts
+type sourceMap = boolean;
 ```
+
 Default: depends on the `compiler.devtool` value
 
 Enables/Disables generation of source maps.
@@ -475,7 +482,8 @@ module.exports = {
 
 ### `additionalData`
 
-Type: 
+Type:
+
 ```ts
 type additionalData = string | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => string
 ```
@@ -583,10 +591,12 @@ module.exports = {
 
 ### `webpackImporter`
 
-Type: 
+Type:
+
 ```ts
-type webpackImporter = boolean
+type webpackImporter = boolean;
 ```
+
 Default: `true`
 
 Enables/Disables the default Webpack importer.
@@ -620,10 +630,12 @@ module.exports = {
 
 ### `warnRuleAsWarning`
 
-Type: 
+Type:
+
 ```ts
-type warnRuleAsWarning = boolean
+type warnRuleAsWarning = boolean;
 ```
+
 Default: `false`
 
 Treats the `@warn` rule as a webpack warning.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,13 @@ module.exports = {
 Type:
 
 ```ts
-type sassOptions = object | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => object
+type sassOptions =
+  | object
+  | ((
+      content: string | Buffer,
+      loaderContext: LoaderContext,
+      meta: any
+    ) => object);
 ```
 
 Default: defaults values for Sass implementation
@@ -485,7 +491,13 @@ module.exports = {
 Type:
 
 ```ts
-type additionalData = string | (content: string|Buffer, loaderContext: LoaderContext, meta: any) => string
+type additionalData =
+  | string
+  | ((
+      content: string | Buffer,
+      loaderContext: LoaderContext,
+      meta: any
+    ) => string);
 ```
 
 Default: `undefined`

--- a/README.md
+++ b/README.md
@@ -493,11 +493,7 @@ Type:
 ```ts
 type additionalData =
   | string
-  | ((
-      content: string | Buffer,
-      loaderContext: LoaderContext,
-      meta: any
-    ) => string);
+  | ((content: string | Buffer, loaderContext: LoaderContext) => string);
 ```
 
 Default: `undefined`


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case
Use primitive types instead of object types in the readme 

Markdown preview link here: https://github.com/webpack-contrib/sass-loader/blob/a1cd3bfdf7a3ec2ab144b6fcb3f960db3bb9153c/README.md