### PR TITLE
Add sass-embedded to default implementations

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -15,8 +15,13 @@ function getDefaultSassImplementation() {
     try {
       require.resolve("node-sass");
       sassImplPkg = "node-sass";
-    } catch (ignoreError) {
-      sassImplPkg = "sass";
+    } catch (error) {
+      try {
+        require.resolve("sass-embedded");
+        sassImplPkg = "sass-embedded";
+      } catch (ignoreError) {
+        sassImplPkg = "sass";
+      }
     }
   }
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Add sass-embedded to default implementations:
While using create-react-app and react-app-rewired I want to use sass-embedded, but config-overrides doesn`t work as expected: 
scssLoader.options.implementation = require('sass-embedded');
doesn`t apply, I`m getting errors like "sass not found". So the easiest way to fix this is to add sass-embedded to getDefaultSassImplementation function.
P.S. Idk if it is a bugfix or feature :D
