### PR TITLE
feat: optimize debug message formatting, #1065

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,13 +780,14 @@ module.exports = {
 
 Defaults, the output of `@debug` messages is disabled.
 To enable it, add to **webpack.config.js** following:
+
 ```js
 module.exports = {
   stats: {
-    loggingDebug: ['sass-loader'],
+    loggingDebug: ["sass-loader"],
   },
-  //...
-}
+  // ...
+};
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -756,6 +756,19 @@ module.exports = {
 };
 ```
 
+## How to enable `@debug` output
+
+Defaults, the output of `@debug` messages is disabled.
+To enable it, add to **webpack.config.js** following:
+```js
+module.exports = {
+  stats: {
+    loggingDebug: ['sass-loader'],
+  },
+  //...
+}
+```
+
 ## Examples
 
 ### Extracts CSS into separate files

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "header-max-length": [0],
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+  },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,7 +157,7 @@ async function getSassOptions(
     const logger = loaderContext.getLogger("sass-loader");
     const formatSpan = (span) =>
       `${span.url || "-"}:${span.start.line}:${span.start.column}: `;
-    const formatDebugSpan = (span) => 
+    const formatDebugSpan = (span) =>
       `[debug:${span.start.line}:${span.start.column}] `;
 
     options.logger = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,13 +157,15 @@ async function getSassOptions(
     const logger = loaderContext.getLogger("sass-loader");
     const formatSpan = (span) =>
       `${span.url || "-"}:${span.start.line}:${span.start.column}: `;
+    const formatDebugSpan = (span) => 
+      `[debug:${span.start.line}:${span.start.column}] `;
 
     options.logger = {
       debug(message, loggerOptions) {
         let builtMessage = "";
 
         if (loggerOptions.span) {
-          builtMessage = formatSpan(loggerOptions.span);
+          builtMessage = formatDebugSpan(loggerOptions.span);
         }
 
         builtMessage += message;


### PR DESCRIPTION
docs: add impofration how to enable @debug output

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

1. The debug message on each line is too long because the output contains an absolute file before self message.
    Here was changed debug message formatting to:  [debug:line:column] message.
2. In readme is added "How to enable @debug output", because since sass-loader 1.12.0 the output of `@debug` is disabled  by default.
 
 Details see in the [issue](https://github.com/webpack-contrib/sass-loader/issues/1065).

### Breaking Changes

NO

### Additional Info
