### PR TITLE
feat: extend conditionNames

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -530,7 +530,7 @@ function getWebpackResolver(
   const webpackModuleResolve = promiseResolve(
     resolverFactory({
       dependencyType: "sass",
-      conditionNames: ["sass", "style"],
+      conditionNames: ["sass", "style", "..."],
       mainFields: ["sass", "style", "main", "..."],
       mainFiles: ["_index", "index", "..."],
       extensions: [".sass", ".scss", ".css"],
@@ -541,7 +541,7 @@ function getWebpackResolver(
   const webpackImportResolve = promiseResolve(
     resolverFactory({
       dependencyType: "sass",
-      conditionNames: ["sass", "style"],
+      conditionNames: ["sass", "style", "..."],
       mainFields: ["sass", "style", "main", "..."],
       mainFiles: ["_index.import", "_index", "index.import", "index", "..."],
       extensions: [".sass", ".scss", ".css"],

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -4,7 +4,7 @@ import fs from "fs";
 
 import { klona } from "klona/full";
 
-async function getCodeFromSass(testId, options) {
+async function getCodeFromSass(testId, options, context = {}) {
   const loaderOptions = klona(options);
   let sassOptions = options.sassOptions || {};
 
@@ -56,6 +56,27 @@ async function getCodeFromSass(testId, options) {
     testFolder,
     "node_modules/package-with-exports/style.scss"
   );
+  const pathToSassPackageWithExportsFieldsAndCustomConditionReplacer = () => {
+    if (context.packageExportsCustomConditionTestVariant === 1) {
+      return path.resolve(
+        testFolder,
+        "node_modules/package-with-exports-and-custom-condition/style-1.scss"
+      );
+    }
+
+    if (context.packageExportsCustomConditionTestVariant === 2) {
+      return path.resolve(
+        testFolder,
+        "node_modules/package-with-exports-and-custom-condition/style-2.scss"
+      );
+    }
+
+    console.warn(
+      "Expedted to receive .packageExportsCustomConditionTestVariant to properly resolve stylesheet in sass only compilation. "
+    );
+    return "";
+  };
+
   const pathToSCSSPackageWithIndexFile = path.resolve(
     testFolder,
     "node_modules/scss-package-with-index/index.scss"
@@ -765,7 +786,11 @@ async function getCodeFromSass(testId, options) {
         )
         .replace(/^~package-with-js-main-field/, pathToPackageWithJsMainField)
         .replace(/^~package-with-index/, pathToPackageWithIndex)
-        .replace(/^package-with-exports/, pathToSassPackageWithExportsFields)
+        .replace(
+          /^package-with-exports-and-custom-condition$/,
+          pathToSassPackageWithExportsFieldsAndCustomConditionReplacer
+        )
+        .replace(/^package-with-exports$/, pathToSassPackageWithExportsFields)
         .replace(/^file:\/\/\/language/, pathToLanguage)
         .replace(/^\/sass\/language.sass/, pathToLanguage)
         .replace(/^\/scss\/language.scss/, pathToLanguage)

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1038,6 +1038,64 @@ describe("loader", () => {
       }
 
       if (!isModernAPI) {
+        it(`should work with a package with "sass" and "exports" fields and a custom condition (theme1) ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId(
+            "import-package-with-exports-and-custom-condition",
+            syntax
+          );
+          const options = {
+            implementation,
+            api,
+          };
+          const compiler = getCompiler(testId, {
+            loader: { options },
+            resolve: {
+              conditionNames: ["theme1", "..."],
+            },
+          });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options, {
+            packageExportsCustomConditionTestVariant: 1,
+          });
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
+
+      if (!isModernAPI) {
+        it(`should work with a package with "sass" and "exports" fields and a custom condition (theme2) ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
+          const testId = getTestId(
+            "import-package-with-exports-and-custom-condition",
+            syntax
+          );
+          const options = {
+            implementation,
+            api,
+          };
+          const compiler = getCompiler(testId, {
+            loader: { options },
+            resolve: {
+              conditionNames: ["theme2", "..."],
+            },
+          });
+          const stats = await compile(compiler);
+          const codeFromBundle = getCodeFromBundle(stats, compiler);
+          const codeFromSass = await getCodeFromSass(testId, options, {
+            packageExportsCustomConditionTestVariant: 2,
+          });
+
+          expect(codeFromBundle.css).toBe(codeFromSass.css);
+          expect(codeFromBundle.css).toMatchSnapshot("css");
+          expect(getWarnings(stats)).toMatchSnapshot("warnings");
+          expect(getErrors(stats)).toMatchSnapshot("errors");
+        });
+      }
+
+      if (!isModernAPI) {
         it(`should support resolving using the "file" schema ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("import-file-scheme", syntax);
           const options = {

--- a/test/node_modules/package-with-exports-and-custom-condition/index.cjs
+++ b/test/node_modules/package-with-exports-and-custom-condition/index.cjs
@@ -1,0 +1,1 @@
+console.log('Some js, clearly not sass');

--- a/test/node_modules/package-with-exports-and-custom-condition/index.js
+++ b/test/node_modules/package-with-exports-and-custom-condition/index.js
@@ -1,0 +1,1 @@
+console.log('Some js, clearly not sass');

--- a/test/node_modules/package-with-exports-and-custom-condition/package.json
+++ b/test/node_modules/package-with-exports-and-custom-condition/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "package-with-exports-and-custom-condition",
+  "version": "1.0.0",
+  "description": "test",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "type": "module",
+  "module": "index.js",
+  "main": "index.cjs",
+  "sass": "style-1.scss",
+  "exports": {
+    "require": "./index.cjs",
+    "import": "./index.js",
+    "sass": {
+      "theme1": "./style-1.scss",
+      "theme2": "./style-2.scss"
+    }
+  }
+}

--- a/test/node_modules/package-with-exports-and-custom-condition/style-1.scss
+++ b/test/node_modules/package-with-exports-and-custom-condition/style-1.scss
@@ -1,0 +1,3 @@
+.load-me {
+  color: red;
+}

--- a/test/node_modules/package-with-exports-and-custom-condition/style-2.scss
+++ b/test/node_modules/package-with-exports-and-custom-condition/style-2.scss
@@ -1,0 +1,3 @@
+.load-me {
+  color: blue;
+}

--- a/test/node_modules/package-with-exports/package.json
+++ b/test/node_modules/package-with-exports/package.json
@@ -12,8 +12,8 @@
   "main": "index.cjs",
   "sass": "style.scss",
   "exports": {
-    "sass": "./style.scss",
     "require": "./index.cjs",
-    "import": "./index.js"
+    "import": "./index.js",
+    "sass": "./style.scss"
   }
 }

--- a/test/sass/import-package-with-exports-and-custom-condition.sass
+++ b/test/sass/import-package-with-exports-and-custom-condition.sass
@@ -1,0 +1,1 @@
+@import 'package-with-exports-and-custom-condition'

--- a/test/scss/import-package-with-exports-and-custom-condition.scss
+++ b/test/scss/import-package-with-exports-and-custom-condition.scss
@@ -1,0 +1,1 @@
+@import 'package-with-exports-and-custom-condition';


### PR DESCRIPTION


<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
This allows consumers to set their own considitionNames and have sass pick this up.

Examples:

Supporting a single entrypoint but targeting multiple themes
```scss
@use 'my-design-tokens';

.class {
  color: my-design-tokens.$color-1
}
```

package.json
```json
{
  "name": "my-design-tokens",
  "exports": {
      ".": {
        "sass": {
          "theme1": "./path-to-theme1.scss",
          "theme2": "./path-to-theme2.scss"
          }
      }
   }
}
```
Webpack config
```
module.exports = {
  resolve: {
    conditionNames: [someFlag ? "theme1" : "theme2", "..."]
  }
}
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info


