### PR TITLE
refactor: load `neo-async` lazily

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,6 @@
 import url from "url";
 import path from "path";
 
-import async from "neo-async";
-
 function getDefaultSassImplementation() {
   let sassImplPkg = "sass";
 
@@ -706,6 +704,9 @@ function getCompileFn(implementation, options) {
   // We need to use a job queue to make sure that one thread is always available to the UV lib
   if (nodeSassJobQueue === null) {
     const threadPoolSize = Number(process.env.UV_THREADPOOL_SIZE || 4);
+    // Only used for `node-sass`, so let's load it lazily
+    // eslint-disable-next-line global-require
+    const async = require("neo-async");
 
     nodeSassJobQueue = async.queue(
       implementation.render.bind(implementation),


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Don't load `neo-async` when it is unnecessary, not only `node-sass` can be used

### Breaking Changes

No

### Additional Info

No