### PR TITLE
[v10] feat: support sass embedded

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -87,6 +87,9 @@ function getSassImplementation(loaderContext, implementation) {
 
     // eslint-disable-next-line consistent-return
     return resolvedImplementation;
+  } else if (implementationName === "sass-embedded") {
+    // eslint-disable-next-line consistent-return
+    return resolvedImplementation;
   }
 
   loaderContext.emitError(


### PR DESCRIPTION
When trying to update the sass engine from the legacy node-sass into the new ones we found that users using webpack v4 doesn't have the ability to use the new sass-embedded implementation as the sass-loader version that supports it doesn't work with webpack v4. This is a good addition because using the javascript sass only implementation has big performance penalties. 