### PR TITLE
[v10] fix: missing sass embedded check when get default implementation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,12 +11,17 @@ function getDefaultSassImplementation() {
 
   try {
     require.resolve("sass");
-  } catch (error) {
+  } catch (ignoreError) {
     try {
       require.resolve("node-sass");
       sassImplPkg = "node-sass";
-    } catch (ignoreError) {
-      sassImplPkg = "sass";
+    } catch (_ignoreError) {
+      try {
+        require.resolve("sass-embedded");
+        sassImplPkg = "sass-embedded";
+      } catch (__ignoreError) {
+        sassImplPkg = "sass";
+      }
     }
   }
 


### PR DESCRIPTION
This is a small fix for what was introduced at https://github.com/webpack-contrib/sass-loader/pull/1152

I haven't realised before but we were missing the sass-embedded check at this place.