### PR TITLE
perf: reuse compiler process when using sass-embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,12 +657,12 @@ module.exports = {
 Type:
 
 ```ts
-type api = "legacy" | "modern";
+type api = "legacy" | "modern" | "modern-compiler";
 ```
 
 Default: `"legacy"`
 
-Allows you to switch between `legacy` and `modern` API. You can find more information [here](https://sass-lang.com/documentation/js-api).
+Allows you to switch between `legacy` and `modern` API. You can find more information [here](https://sass-lang.com/documentation/js-api). The `modern-compiler` option enables the modern API with support for [Shared Resources](https://github.com/sass/sass/blob/main/accepted/shared-resources.d.ts.md).
 
 > **Warning**
 >

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ async function loader(content) {
   let result;
 
   try {
-    result = await compile(sassOptions, options);
+    result = await compile(sassOptions);
   } catch (error) {
     // There are situations when the `file`/`span.url` property do not exist
     // Modern API

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,8 @@ async function loader(content) {
       : true;
 
   if (shouldUseWebpackImporter) {
-    const isModernAPI = options.api === "modern";
+    const isModernAPI =
+      options.api === "modern" || options.api === "modern-compiler";
 
     if (!isModernAPI) {
       const { includePaths } = sassOptions;
@@ -65,7 +66,7 @@ async function loader(content) {
   let compile;
 
   try {
-    compile = getCompileFn(implementation, options);
+    compile = getCompileFn(this, implementation, options);
   } catch (error) {
     callback(error);
     return;

--- a/src/options.json
+++ b/src/options.json
@@ -17,7 +17,7 @@
     "api": {
       "description": "Switch between old and modern API for `sass` (`Dart Sass`) and `Sass Embedded` implementations.",
       "link": "https://github.com/webpack-contrib/sass-loader#sassoptions",
-      "enum": ["legacy", "modern"]
+      "enum": ["legacy", "modern", "modern-compiler"]
     },
     "sassOptions": {
       "description": "Options for `node-sass` or `sass` (`Dart Sass`) implementation.",

--- a/src/utils.js
+++ b/src/utils.js
@@ -697,7 +697,9 @@ function getCompileFn(loaderContext, implementation, options) {
               });
             }
           }
-          return sassModernCompilers.get(implementation).compileStringAsync(data, rest);
+          return sassModernCompilers
+            .get(implementation)
+            .compileStringAsync(data, rest);
         }
 
         return implementation.compileStringAsync(data, rest);

--- a/test/__snapshots__/additionalData-option.test.js.snap
+++ b/test/__snapshots__/additionalData-option.test.js.snap
@@ -56,6 +56,34 @@ exports[`additionalData option should use same EOL on all os ('dart-sass', 'mode
 
 exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: hotpink;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`additionalData option should use same EOL on all os ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "a {
   color: hotpink; }
@@ -138,6 +166,34 @@ exports[`additionalData option should use same EOL on all os ('sass-embedded', '
 
 exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: hotpink;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}
+
+body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should use same EOL on all os ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`additionalData option should work as a function ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -177,6 +233,26 @@ exports[`additionalData option should work as a function ('dart-sass', 'modern' 
 exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`additionalData option should work as a function ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`additionalData option should work as a function ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
@@ -238,6 +314,26 @@ exports[`additionalData option should work as a function ('sass-embedded', 'mode
 
 exports[`additionalData option should work as a function ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`additionalData option should work as a string ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -277,6 +373,26 @@ exports[`additionalData option should work as a string ('dart-sass', 'modern' AP
 exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`additionalData option should work as a string ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`additionalData option should work as a string ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
@@ -338,6 +454,26 @@ exports[`additionalData option should work as a string ('sass-embedded', 'modern
 
 exports[`additionalData option should work as a string ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as a string ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`additionalData option should work as an async function ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
   color: hotpink;
@@ -377,6 +513,26 @@ exports[`additionalData option should work as an async function ('dart-sass', 'm
 exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`additionalData option should work as an async function ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`additionalData option should work as an async function ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "body {
@@ -437,3 +593,23 @@ exports[`additionalData option should work as an async function ('sass-embedded'
 exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`additionalData option should work as an async function ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"body {
+  color: hotpink;
+}"
+`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`additionalData option should work as an async function ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;

--- a/test/__snapshots__/implementation-option.test.js.snap
+++ b/test/__snapshots__/implementation-option.test.js.snap
@@ -8,6 +8,10 @@ exports[`implementation option 'dart-sass', 'modern' API: errors 1`] = `[]`;
 
 exports[`implementation option 'dart-sass', 'modern' API: warnings 1`] = `[]`;
 
+exports[`implementation option 'dart-sass', 'modern-compiler' API: errors 1`] = `[]`;
+
+exports[`implementation option 'dart-sass', 'modern-compiler' API: warnings 1`] = `[]`;
+
 exports[`implementation option 'node-sass', 'legacy' API: errors 1`] = `[]`;
 
 exports[`implementation option 'node-sass', 'legacy' API: warnings 1`] = `[]`;
@@ -23,6 +27,10 @@ exports[`implementation option 'sass-embedded', 'legacy' API: warnings 1`] = `[]
 exports[`implementation option 'sass-embedded', 'modern' API: errors 1`] = `[]`;
 
 exports[`implementation option 'sass-embedded', 'modern' API: warnings 1`] = `[]`;
+
+exports[`implementation option 'sass-embedded', 'modern-compiler' API: errors 1`] = `[]`;
+
+exports[`implementation option 'sass-embedded', 'modern-compiler' API: warnings 1`] = `[]`;
 
 exports[`implementation option not specify with legacy API: errors 1`] = `[]`;
 

--- a/test/__snapshots__/implementation-option.test.js.snap
+++ b/test/__snapshots__/implementation-option.test.js.snap
@@ -40,6 +40,10 @@ exports[`implementation option not specify with modern API: errors 1`] = `[]`;
 
 exports[`implementation option not specify with modern API: warnings 1`] = `[]`;
 
+exports[`implementation option not specify with modern-compiler API: errors 1`] = `[]`;
+
+exports[`implementation option not specify with modern-compiler API: warnings 1`] = `[]`;
+
 exports[`implementation option not specify: errors 1`] = `[]`;
 
 exports[`implementation option not specify: warnings 1`] = `[]`;
@@ -52,6 +56,14 @@ Some error",
 `;
 
 exports[`implementation option should not swallow an error when trying to load a sass implementation: warnings 1`] = `[]`;
+
+exports[`implementation option should support switching the implementation within the same process when using the modern-compiler API: errors 1`] = `[]`;
+
+exports[`implementation option should support switching the implementation within the same process when using the modern-compiler API: errors 2`] = `[]`;
+
+exports[`implementation option should support switching the implementation within the same process when using the modern-compiler API: warnings 1`] = `[]`;
+
+exports[`implementation option should support switching the implementation within the same process when using the modern-compiler API: warnings 2`] = `[]`;
 
 exports[`implementation option should throw an error on an unknown sass implementation: errors 1`] = `
 [

--- a/test/__snapshots__/sassOptions-option.test.js.snap
+++ b/test/__snapshots__/sassOptions-option.test.js.snap
@@ -204,6 +204,108 @@ exports[`sassOptions option should ignore the "data" option ('dart-sass', 'moder
 
 exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should ignore the "data" option ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import url(./file.css);
@@ -497,6 +599,108 @@ nav a {
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "data" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should ignore the "file" option ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -894,6 +1098,108 @@ exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern
 
 exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -995,6 +1301,108 @@ nav a {
 exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should ignore the "url" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -1199,6 +1607,108 @@ nav a {
 exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should respect the "outputStyle"/"style" option ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -1512,6 +2022,108 @@ exports[`sassOptions option should respect the "outputStyle"/"style" option ('sa
 
 exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should respect the "outputStyle"/"style" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `"﻿@import"./file.css";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:""}.bar:before{content:"∑"}"`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
@@ -1535,6 +2147,18 @@ exports[`sassOptions option should use "compressed" output style in the "product
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `"﻿@import"./file.css";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:""}.bar:before{content:"∑"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `"﻿@import"./file.css";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:""}.bar:before{content:"∑"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "﻿@import url(./file.css);body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.success,.error,.warning{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:yellow}.foo:before{content:""}.bar:before{content:"∑"}
@@ -1577,6 +2201,18 @@ exports[`sassOptions option should use "compressed" output style in the "product
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `"@import"./file.css";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.message,.warning,.error,.success{border:1px solid #ccc;padding:10px;color:#333}.success{border-color:green}.error{border-color:red}.warning{border-color:#ff0}.foo:before{content:""}.bar:before{content:"∑"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `"@import"./file.css";body{font:100% Helvetica,sans-serif;color:#333}nav ul{margin:0;padding:0;list-style:none}nav li{display:inline-block}nav a{display:block;padding:6px 12px;text-decoration:none}.box{-webkit-border-radius:10px;-moz-border-radius:10px;-ms-border-radius:10px;border-radius:10px}.foo:before{content:""}.bar:before{content:"∑"}"`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should use "compressed" output style in the "production" mode ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -1781,6 +2417,108 @@ nav a {
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work when the option is empty "Object" ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -2076,6 +2814,108 @@ exports[`sassOptions option should work when the option is empty "Object" ('sass
 
 exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option is empty "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -2279,6 +3119,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Function" ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -2574,6 +3516,108 @@ exports[`sassOptions option should work when the option like "Function" ('sass-e
 
 exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -2777,6 +3821,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Function" and never return ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -3072,6 +4218,108 @@ exports[`sassOptions option should work when the option like "Function" and neve
 
 exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Function" and never return ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -3275,6 +4523,108 @@ nav a {
 exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work when the option like "Object" ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -3570,6 +4920,108 @@ exports[`sassOptions option should work when the option like "Object" ('sass-emb
 
 exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work when the option like "Object" ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
@@ -3578,6 +5030,14 @@ exports[`sassOptions option should work with custom scheme import ('dart-sass', 
 
 exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
@@ -3585,6 +5045,14 @@ exports[`sassOptions option should work with custom scheme import ('sass-embedde
 exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with custom scheme import ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work with the "functions" option ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "h2, h3, h4, h5 {
@@ -3888,6 +5356,34 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 ".include-path-module {
   background: hotpink; }
@@ -3969,6 +5465,34 @@ exports[`sassOptions option should work with the "includePaths"/"loadPaths" opti
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+".include-path-module {
+  background: hotpink;
+}
+
+._underscore-include-path-module {
+  background: hotpink;
+}"
+`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "includePaths"/"loadPaths" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work with the "indentType" option ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -4762,6 +6286,108 @@ exports[`sassOptions option should work with the "indentedSyntax"/"syntax" optio
 
 exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import url(./file.css);
@@ -5055,6 +6681,108 @@ nav a {
 exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
 exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sassOptions option should work with the "indentedSyntax"/"syntax" option ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sassOptions option should work with the "linefeed" option ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -375,6 +375,134 @@ exports[`sourceMap option should generate source maps when value has "false" val
 
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import url(./file.css);
@@ -987,6 +1115,134 @@ exports[`sourceMap option should generate source maps when value has "false" val
 
 exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "false" value, but the "sassOptions.sourceMap" has the "true" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -1359,6 +1615,134 @@ exports[`sourceMap option should generate source maps when value has "true" valu
 `;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -1968,6 +2352,134 @@ exports[`sourceMap option should generate source maps when value has "true" valu
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -2340,6 +2852,134 @@ exports[`sourceMap option should generate source maps when value has "true" valu
 `;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -2949,6 +3589,134 @@ exports[`sourceMap option should generate source maps when value has "true" valu
 
 exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value has "true" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -3321,6 +4089,134 @@ exports[`sourceMap option should generate source maps when value is not specifie
 `;
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -3930,6 +4826,134 @@ exports[`sourceMap option should generate source maps when value is not specifie
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SCzDc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language.sass",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;AAMR;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SC7Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -4141,6 +5165,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -4448,6 +5578,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -4659,6 +5895,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -4966,6 +6308,112 @@ exports[`sourceMap option should not generate source maps when value has "false"
 
 exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value has "false" value and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
@@ -5177,6 +6625,112 @@ exports[`sourceMap option should not generate source maps when value is not spec
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -5483,3 +7037,109 @@ exports[`sourceMap option should not generate source maps when value is not spec
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `undefined`;
 
 exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `undefined`;
+
+exports[`sourceMap option should not generate source maps when value is not specified and the "devtool" option has "false" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -14,7 +14,7 @@ exports[`validate options should throw an error on the "additionalData" option w
 exports[`validate options should throw an error on the "api" option with "string" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options.api should be one of these:
-   "legacy" | "modern"
+   "legacy" | "modern" | "modern-compiler"
    -> Switch between old and modern API for \`sass\` (\`Dart Sass\`) and \`Sass Embedded\` implementations.
    -> Read more at https://github.com/webpack-contrib/sass-loader#sassoptions"
 `;
@@ -22,7 +22,7 @@ exports[`validate options should throw an error on the "api" option with "string
 exports[`validate options should throw an error on the "api" option with "true" value 1`] = `
 "Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
  - options.api should be one of these:
-   "legacy" | "modern"
+   "legacy" | "modern" | "modern-compiler"
    -> Switch between old and modern API for \`sass\` (\`Dart Sass\`) and \`Sass Embedded\` implementations.
    -> Read more at https://github.com/webpack-contrib/sass-loader#sassoptions"
 `;

--- a/test/__snapshots__/warnRuleAsWarning.test.js.snap
+++ b/test/__snapshots__/warnRuleAsWarning.test.js.snap
@@ -34,6 +34,23 @@ This selector doesn't have any properties and won't be rendered.
 ]
 `;
 
+exports[`loader should emit good formatted warning ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `""`;
+
+exports[`loader should emit good formatted warning ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit good formatted warning ('dart-sass', 'modern-compiler' API, 'sass' syntax): logs 1`] = `[]`;
+
+exports[`loader should emit good formatted warning ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+Warning on line 5, column 3 of file:///test/sass/broken.sass:5:3:
+This selector doesn't have any properties and won't be rendered.
+
+5 |    asdf
+",
+]
+`;
+
 exports[`loader should emit good formatted warning ('sass-embedded', 'legacy' API, 'sass' syntax): css 1`] = `""`;
 
 exports[`loader should emit good formatted warning ('sass-embedded', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
@@ -58,6 +75,23 @@ exports[`loader should emit good formatted warning ('sass-embedded', 'modern' AP
 exports[`loader should emit good formatted warning ('sass-embedded', 'modern' API, 'sass' syntax): logs 1`] = `[]`;
 
 exports[`loader should emit good formatted warning ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+Warning on line 5, column 3 of file:///test/sass/broken.sass:5:3:
+This selector doesn't have any properties and won't be rendered.
+
+5 |    asdf
+",
+]
+`;
+
+exports[`loader should emit good formatted warning ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `""`;
+
+exports[`loader should emit good formatted warning ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit good formatted warning ('sass-embedded', 'modern-compiler' API, 'sass' syntax): logs 1`] = `[]`;
+
+exports[`loader should emit good formatted warning ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
 [
   "ModuleWarning: Module Warning (from ../src/cjs.js):
 Warning on line 5, column 3 of file:///test/sass/broken.sass:5:3:
@@ -174,6 +208,62 @@ exports[`loader should emit warning by default ('dart-sass', 'modern' API, 'scss
 `;
 
 exports[`loader should emit warning by default ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning by default ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `
 [
   "ModuleWarning: Module Warning (from ../src/cjs.js):
 My warning message",
@@ -316,6 +406,62 @@ My warning message",
 ]
 `;
 
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning by default ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
 exports[`loader should emit warning when 'true' used ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -422,6 +568,62 @@ exports[`loader should emit warning when 'true' used ('dart-sass', 'modern' API,
 `;
 
 exports[`loader should emit warning when 'true' used ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `
 [
   "ModuleWarning: Module Warning (from ../src/cjs.js):
 My warning message",
@@ -564,6 +766,62 @@ My warning message",
 ]
 `;
 
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+  ],
+]
+`;
+
+exports[`loader should emit warning when 'true' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `
+[
+  "ModuleWarning: Module Warning (from ../src/cjs.js):
+My warning message",
+]
+`;
+
 exports[`loader should not emit warning when 'false' used ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "a {
   color: red;
@@ -691,6 +949,70 @@ test/scss/logging.scss 2:1  root stylesheet
 `;
 
 exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+    {
+      "args": [
+        "My warning message
+
+test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+    {
+      "args": [
+        "My warning message
+
+test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`loader should not emit warning when 'false' used ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "a {
@@ -843,3 +1165,67 @@ exports[`loader should not emit warning when 'false' used ('sass-embedded', 'mod
 `;
 
 exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+    {
+      "args": [
+        "My warning message
+
+../../../../test/sass/logging.sass 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"a {
+  color: red;
+}"
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): logs 1`] = `
+[
+  [
+    {
+      "args": [
+        "[debug:0:0] My debug message",
+      ],
+      "type": "debug",
+    },
+    {
+      "args": [
+        "My warning message
+
+../../../../test/scss/logging.scss 2:1  root stylesheet
+",
+      ],
+      "type": "warn",
+    },
+  ],
+]
+`;
+
+exports[`loader should not emit warning when 'false' used ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;

--- a/test/helpers/customFunctions.js
+++ b/test/helpers/customFunctions.js
@@ -1,5 +1,5 @@
 export default (api, implementation) => {
-  if (api === "modern") {
+  if (api === "modern" || api === "modern-compiler") {
     return {
       // Note: in real code, you should use `math.pow()` from the built-in
       // `sass:math` module.

--- a/test/helpers/getCodeFromSass.js
+++ b/test/helpers/getCodeFromSass.js
@@ -16,7 +16,8 @@ async function getCodeFromSass(testId, options, context = {}) {
   const { implementation } = loaderOptions;
   const isNodeSassImplementation =
     loaderOptions.implementation.info.includes("node-sass");
-  const isModernAPI = options.api === "modern";
+  const isModernAPI =
+    options.api === "modern" || options.api === "modern-compiler";
 
   delete loaderOptions.implementation;
 

--- a/test/helpers/getImplementationByName.js
+++ b/test/helpers/getImplementationByName.js
@@ -5,6 +5,9 @@ function getImplementationByName(implementationName) {
   } else if (implementationName === "dart-sass") {
     // eslint-disable-next-line global-require
     return require("sass");
+  } else if (implementationName === "sass-embedded") {
+    // eslint-disable-next-line global-require
+    return require("sass-embedded");
   } else if (implementationName === "sass_string") {
     return require.resolve("sass");
   }

--- a/test/helpers/getImplementationsAndAPI.js
+++ b/test/helpers/getImplementationsAndAPI.js
@@ -21,6 +21,11 @@ export default function getImplementationsAndAPI() {
       api: "modern",
     },
     {
+      name: dartSass.info.split("\t")[0],
+      implementation: dartSass,
+      api: "modern-compiler",
+    },
+    {
       name: SassEmbedded.info.split("\t")[0],
       implementation: SassEmbedded,
       api: "legacy",
@@ -29,6 +34,11 @@ export default function getImplementationsAndAPI() {
       name: SassEmbedded.info.split("\t")[0],
       implementation: SassEmbedded,
       api: "modern",
+    },
+    {
+      name: SassEmbedded.info.split("\t")[0],
+      implementation: SassEmbedded,
+      api: "modern-compiler",
     },
   ];
 }

--- a/test/implementation-option.test.js
+++ b/test/implementation-option.test.js
@@ -18,6 +18,29 @@ jest.setTimeout(30000);
 
 const implementations = [...getImplementationsAndAPI(), "sass_string"];
 
+/** Helper to create spy functions for the modern Compiler API */
+const spyOnCompiler = (implementation) => {
+  const actualFn = implementation.initAsyncCompiler.bind(implementation);
+
+  const initSpy = jest
+    .spyOn(implementation, "initAsyncCompiler")
+    .mockImplementation(async () => {
+      const compiler = await actualFn();
+      // eslint-disable-next-line no-use-before-define
+      spies.compileStringSpy = jest.spyOn(compiler, "compileStringAsync");
+      return compiler;
+    });
+
+  const mockRestore = () => initSpy.mockRestore();
+
+  const spies = {
+    initSpy,
+    mockRestore,
+  };
+
+  return spies;
+};
+
 describe("implementation option", () => {
   implementations.forEach((item) => {
     let implementationName;
@@ -36,11 +59,13 @@ describe("implementation option", () => {
       const nodeSassSpy = jest.spyOn(nodeSass, "render");
       const dartSassSpy = jest.spyOn(dartSass, "render");
       const dartSassSpyModernAPI = jest.spyOn(dartSass, "compileStringAsync");
+      const dartSassCompilerSpies = spyOnCompiler(dartSass);
       const sassEmbeddedSpy = jest.spyOn(sassEmbedded, "render");
       const sassEmbeddedSpyModernAPI = jest.spyOn(
         sassEmbedded,
         "compileStringAsync",
       );
+      const sassEmbeddedCompilerSpies = spyOnCompiler(sassEmbedded);
 
       const testId = getTestId("language", "scss");
       const options = { api, implementation };
@@ -58,8 +83,10 @@ describe("implementation option", () => {
         expect(nodeSassSpy).toHaveBeenCalledTimes(1);
         expect(dartSassSpy).toHaveBeenCalledTimes(0);
         expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+        expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
         expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
         expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+        expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
       } else if (
         implementationName === "dart-sass" ||
         implementationName === "dart-sass_string"
@@ -68,36 +95,68 @@ describe("implementation option", () => {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(1);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
+        } else if (api === "modern-compiler") {
+          expect(nodeSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(1);
+          expect(dartSassCompilerSpies.compileStringSpy).toHaveBeenCalledTimes(
+            1,
+          );
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
         } else if (api === "legacy") {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(1);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
         }
       } else if (implementationName === "sass-embedded") {
         if (api === "modern") {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(1);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
+        } else if (api === "modern-compiler") {
+          expect(nodeSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpy).toHaveBeenCalledTimes(0);
+          expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpy).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(1);
+          expect(
+            sassEmbeddedCompilerSpies.compileStringSpy,
+          ).toHaveBeenCalledTimes(1);
         } else if (api === "legacy") {
           expect(nodeSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpy).toHaveBeenCalledTimes(0);
           expect(dartSassSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
           expect(sassEmbeddedSpy).toHaveBeenCalledTimes(1);
           expect(sassEmbeddedSpyModernAPI).toHaveBeenCalledTimes(0);
+          expect(sassEmbeddedCompilerSpies.initSpy).toHaveBeenCalledTimes(0);
         }
       }
 
       nodeSassSpy.mockRestore();
       dartSassSpy.mockRestore();
       dartSassSpyModernAPI.mockRestore();
+      dartSassCompilerSpies.mockRestore();
       sassEmbeddedSpy.mockRestore();
       sassEmbeddedSpyModernAPI.mockRestore();
+      sassEmbeddedCompilerSpies.mockRestore();
     });
   });
 
@@ -184,6 +243,37 @@ describe("implementation option", () => {
 
     nodeSassSpy.mockRestore();
     dartSassSpy.mockRestore();
+  });
+
+  it.skip("not specify with modern-compiler API", async () => {
+    const nodeSassSpy = jest.spyOn(nodeSass, "render");
+    const dartSassSpy = jest.spyOn(dartSass, "compileStringAsync");
+    const dartSassCompilerSpies = spyOnCompiler(dartSass);
+
+    const testId = getTestId("language", "scss");
+    const options = {
+      api: "modern-compiler",
+    };
+    const compiler = getCompiler(testId, { loader: { options } });
+    const stats = await compile(compiler);
+    const { css, sourceMap } = getCodeFromBundle(stats, compiler);
+
+    expect(css).toBeDefined();
+    expect(sourceMap).toBeUndefined();
+
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+
+    expect(nodeSassSpy).toHaveBeenCalledTimes(0);
+    expect(dartSassSpy).toHaveBeenCalledTimes(0);
+    // TODO: this isn't being called because the compiler is already initialized
+    //  from a previous test.
+    expect(dartSassCompilerSpies.initSpy).toHaveBeenCalledTimes(1);
+    expect(dartSassCompilerSpies.compileStringSpy).toHaveBeenCalledTimes(1);
+
+    nodeSassSpy.mockRestore();
+    dartSassSpy.mockRestore();
+    dartSassCompilerSpies.mockRestore();
   });
 
   it("should throw an error on an unknown sass implementation", async () => {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -25,7 +25,7 @@ describe("loader", () => {
     // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
     const isSassEmbedded = implementationName === "sass-embedded";
     const isNodeSass = implementationName === "node-sass";
-    const isModernAPI = api === "modern";
+    const isModernAPI = api === "modern" || api === "modern-compiler";
 
     syntaxStyles.forEach((syntax) => {
       it(`should work ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {

--- a/test/sassOptions-option.test.js
+++ b/test/sassOptions-option.test.js
@@ -23,7 +23,7 @@ const syntaxStyles = ["scss", "sass"];
 describe("sassOptions option", () => {
   implementations.forEach((item) => {
     const { name: implementationName, api, implementation } = item;
-    const isModernAPI = api === "modern";
+    const isModernAPI = api === "modern" || api === "modern-compiler";
 
     syntaxStyles.forEach((syntax) => {
       it(`should work when the option like "Object" ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
@@ -74,7 +74,9 @@ describe("sassOptions option", () => {
           sassOptions: (loaderContext) => {
             expect(loaderContext).toBeDefined();
 
-            return api === "modern" ? {} : { indentWidth: 10 };
+            return api === "modern" || api === "modern-compiler"
+              ? {}
+              : { indentWidth: 10 };
           },
         };
         const compiler = getCompiler(testId, { loader: { options } });
@@ -209,7 +211,9 @@ describe("sassOptions option", () => {
       if (!isModernAPI) {
         it(`should work with the "functions" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId(
-            api === "modern" ? "custom-functions-modern" : "custom-functions",
+            api === "modern" || api === "modern-compiler"
+              ? "custom-functions-modern"
+              : "custom-functions",
             syntax,
           );
           const options = {
@@ -327,7 +331,7 @@ describe("sassOptions option", () => {
           implementation,
           api,
           sassOptions:
-            api === "modern"
+            api === "modern" || api === "modern-compiler"
               ? {
                   loadPaths: [path.resolve(__dirname, syntax, "includePath")],
                 }
@@ -348,7 +352,7 @@ describe("sassOptions option", () => {
         expect(getErrors(stats)).toMatchSnapshot("errors");
       });
 
-      if (api !== "modern") {
+      if (api !== "modern" && api !== "modern-compiler") {
         it(`should work with the "indentType" option ('${implementationName}', '${api}' API, '${syntax}' syntax)`, async () => {
           const testId = getTestId("language", syntax);
           const options = {
@@ -395,7 +399,7 @@ describe("sassOptions option", () => {
           implementation,
           api,
           sassOptions:
-            api === "modern"
+            api === "modern" || api === "modern-compiler"
               ? {
                   syntax: syntax === "sass" ? "indented" : "scss",
                 }
@@ -421,7 +425,10 @@ describe("sassOptions option", () => {
             implementation,
             api,
             // Doesn't supported by modern API
-            sassOptions: api === "modern" ? {} : { linefeed: "lf" },
+            sassOptions:
+              api === "modern" || api === "modern-compiler"
+                ? {}
+                : { linefeed: "lf" },
           };
           const compiler = getCompiler(testId, { loader: { options } });
           const stats = await compile(compiler);
@@ -441,7 +448,7 @@ describe("sassOptions option", () => {
           implementation,
           api,
           sassOptions:
-            api === "modern"
+            api === "modern" || api === "modern-compiler"
               ? { style: "expanded" }
               : { outputStyle: "expanded" },
         };
@@ -471,7 +478,7 @@ describe("sassOptions option", () => {
         const codeFromSass = await getCodeFromSass(testId, {
           ...options,
           sassOptions:
-            api === "modern"
+            api === "modern" || api === "modern-compiler"
               ? { style: "compressed" }
               : { outputStyle: "compressed" },
         });

--- a/test/sourceMap-options.test.js
+++ b/test/sourceMap-options.test.js
@@ -146,7 +146,7 @@ describe("sourceMap option", () => {
         sourceMap.sources = sourceMap.sources.map((source) => {
           let normalizedSource = source;
 
-          if (api === "modern") {
+          if (api === "modern" || api === "modern-compiler") {
             normalizedSource = url.fileURLToPath(normalizedSource);
 
             expect(source).toMatch(/^file:/);

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -47,7 +47,7 @@ describe("validate options", () => {
       failure: ["string"],
     },
     api: {
-      success: ["legacy", "modern"],
+      success: ["legacy", "modern", "modern-compiler"],
       failure: ["string", true],
     },
     unknown: {

--- a/test/webpackImporter-options.test.js
+++ b/test/webpackImporter-options.test.js
@@ -18,7 +18,7 @@ describe("webpackImporter option", () => {
       const { name: implementationName, api, implementation } = item;
 
       // TODO fix me https://github.com/webpack-contrib/sass-loader/issues/774
-      if (api === "modern") {
+      if (api === "modern" || api === "modern-compiler") {
         return;
       }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
This implements the Shared Resources proposal that was accepted and implemented in Dart Sass 1.70.0. By reusing the same compiler process when compiling multiple files, this significantly improves performance for tools like webpack.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
None

### Additional Info

Closes: https://github.com/webpack-contrib/sass-loader/issues/1163