### PR TITLE
fix: remove incorrect parameter documentation of `sassOptions` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ module.exports = {
           {
             loader: "sass-loader",
             options: {
-              sassOptions: (content, loaderContext) => {
+              sassOptions: (loaderContext) => {
                 // More information about available properties https://webpack.js.org/api/loaders/
                 const { resourcePath, rootContext } = loaderContext;
                 const relativePath = path.relative(rootContext, resourcePath);


### PR DESCRIPTION
Fixes the incorrect `content` parameter in the documentation of the `sassOptions` function, closes #1226