### PR TITLE
fix: generate correct sourceMaps when custom importer is used

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -691,7 +691,7 @@ function getModernWebpackImporter(loaderContext, implementation, loadPaths) {
           });
         });
 
-        return { contents, syntax };
+        return { contents, syntax, sourceMapUrl: canonicalUrl };
       } catch (err) {
         return null;
       }

--- a/test/__snapshots__/sourceMap-options.test.js.no-node-sass.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.no-node-sass.snap
@@ -634,7 +634,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:11"",
+@import "sass-embedded-legacy-load-done:13"",
   ],
   "version": 3,
 }
@@ -1639,7 +1639,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:10"",
+@import "sass-embedded-legacy-load-done:12"",
   ],
   "version": 3,
 }
@@ -2643,7 +2643,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:9"",
+@import "sass-embedded-legacy-load-done:11"",
   ],
   "version": 3,
 }
@@ -3647,7 +3647,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:8"",
+@import "sass-embedded-legacy-load-done:10"",
   ],
   "version": 3,
 }
@@ -4019,6 +4019,1092 @@ exports[`sourceMap option should generate source maps when value is not specifie
 `;
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "sourcesContent": [
+    "@import "another/variables"
+@import "./file.css"
+@import "module"
+
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+$pi:            '\\e0C6'
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none
+
+=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)
+
+.message
+  border: 1px solid #ccc
+  padding: 10px
+  color: #333
+
+.success
+  @extend .message
+  border-color: green
+
+.error
+  @extend .message
+  border-color: red
+
+.warning
+  @extend .message
+  border-color: yellow
+
+.foo
+  &:before
+    content: $pi
+
+.bar
+  &:before
+    content: $n-ary-summation
+
+",
+    ".module {
+    background: hotpink;
+}
+",
+    "$n-ary-summation: '\\2211'
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}
+",
+    ".module {
+    background: hotpink;
+}
+",
+    "$n-ary-summation: '\\2211'
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "sourcesContent": [
+    "@import "another/variables"
+@import "./file.css"
+@import "module"
+
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+$pi:            '\\e0C6'
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none
+
+=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)
+
+.message
+  border: 1px solid #ccc
+  padding: 10px
+  color: #333
+
+.success
+  @extend .message
+  border-color: green
+
+.error
+  @extend .message
+  border-color: red
+
+.warning
+  @extend .message
+  border-color: yellow
+
+.foo
+  &:before
+    content: $pi
+
+.bar
+  &:before
+    content: $n-ary-summation
+
+",
+    ".module {
+    background: hotpink;
+}
+
+;@import "sass-embedded-legacy-load-done:19";",
+    "$n-ary-summation: '\\2211'
+
+@import "sass-embedded-legacy-load-done:18"",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}
+",
+    ".module {
+    background: hotpink;
+}
+
+;@import "sass-embedded-legacy-load-done:9";",
+    "$n-ary-summation: '\\2211'
+
+;@import "sass-embedded-legacy-load-done:8";",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate sourcemap with "asset/resource" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -4665,7 +5751,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:15"",
+@import "sass-embedded-legacy-load-done:17"",
   ],
   "version": 3,
 }

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -869,7 +869,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:11"",
+@import "sass-embedded-legacy-load-done:13"",
   ],
   "version": 3,
 }
@@ -2107,7 +2107,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:10"",
+@import "sass-embedded-legacy-load-done:12"",
   ],
   "version": 3,
 }
@@ -3344,7 +3344,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:9"",
+@import "sass-embedded-legacy-load-done:11"",
   ],
   "version": 3,
 }
@@ -4581,7 +4581,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:8"",
+@import "sass-embedded-legacy-load-done:10"",
   ],
   "version": 3,
 }
@@ -4953,6 +4953,1343 @@ exports[`sourceMap option should generate source maps when value is not specifie
 `;
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "sourcesContent": [
+    "@import "another/variables"
+@import "./file.css"
+@import "module"
+
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+$pi:            '\\e0C6'
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none
+
+=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)
+
+.message
+  border: 1px solid #ccc
+  padding: 10px
+  color: #333
+
+.success
+  @extend .message
+  border-color: green
+
+.error
+  @extend .message
+  border-color: red
+
+.warning
+  @extend .message
+  border-color: yellow
+
+.foo
+  &:before
+    content: $pi
+
+.bar
+  &:before
+    content: $n-ary-summation
+
+",
+    ".module {
+    background: hotpink;
+}
+",
+    "$n-ary-summation: '\\2211'
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}
+",
+    ".module {
+    background: hotpink;
+}
+",
+    "$n-ary-summation: '\\2211'
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import url(./file.css);
+.module {
+  background: hotpink; }
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.message, .success, .error, .warning {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  border-color: green; }
+
+.error {
+  border-color: red; }
+
+.warning {
+  border-color: yellow; }
+
+.foo:before {
+  content: ""; }
+
+.bar:before {
+  content: "∑"; }
+"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACA,OAAO,CAAP,eAAO;AEDP,AAAA,OAAO,CAAC;EACJ,UAAU,EAAE,OAAO,GACtB;;AFMD,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC1DO,IAAO,GD0DO",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/sass/another/variables.sass",
+    "test/node_modules/module/module.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import "module";
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color; }
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+
+  li {
+    display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none; } }
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+  -moz-border-radius:    $radius;
+  -ms-border-radius:     $radius;
+  border-radius:         $radius; }
+
+.box {
+  @include border-radius(10px); }
+
+.message {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333; }
+
+.success {
+  @extend .message;
+  border-color: green; }
+
+.error {
+  @extend .message;
+  border-color: red; }
+
+.warning {
+  @extend .message;
+  border-color: yellow; }
+
+.foo {
+  &:before {
+    content: $pi; } }
+
+.bar {
+  &:before {
+    content: $n-ary-summation; } }
+
+",
+    "$n-ary-summation: '\\2211';
+",
+    ".module {
+    background: hotpink;
+}
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import url(./file.css);
+.module {
+  background: hotpink; }
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333; }
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+nav li {
+  display: inline-block; }
+
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none; }
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px; }
+
+.foo:before {
+  content: ""; }
+
+.bar:before {
+  content: "∑"; }
+"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACA,OAAO,CAAP,eAAO;AEDP,AAAA,OAAO,CAAC;EACJ,UAAU,EAAE,OAAO,GACtB;;AFMD,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC9CO,IAAO,GD+CtB",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/scss/another/_variables.scss",
+    "test/node_modules/module/module.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}
+",
+    "$n-ary-summation: '\\2211'
+",
+    ".module {
+    background: hotpink;
+}
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "sourcesContent": [
+    "@import "another/variables"
+@import "./file.css"
+@import "module"
+
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+$pi:            '\\e0C6'
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none
+
+=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)
+
+.message
+  border: 1px solid #ccc
+  padding: 10px
+  color: #333
+
+.success
+  @extend .message
+  border-color: green
+
+.error
+  @extend .message
+  border-color: red
+
+.warning
+  @extend .message
+  border-color: yellow
+
+.foo
+  &:before
+    content: $pi
+
+.bar
+  &:before
+    content: $n-ary-summation
+
+",
+    ".module {
+    background: hotpink;
+}
+
+;@import "sass-embedded-legacy-load-done:19";",
+    "$n-ary-summation: '\\2211'
+
+@import "sass-embedded-legacy-load-done:18"",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "sourcesContent": [
+    "@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}
+",
+    ".module {
+    background: hotpink;
+}
+
+;@import "sass-embedded-legacy-load-done:9";",
+    "$n-ary-summation: '\\2211'
+
+;@import "sass-embedded-legacy-load-done:8";",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.message, .warning, .error, .success {
+  border: 1px solid #ccc;
+  padding: 10px;
+  color: #333;
+}
+
+.success {
+  border-color: green;
+}
+
+.error {
+  border-color: red;
+}
+
+.warning {
+  border-color: yellow;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/sass/language-source-maps.sass",
+    "test/node_modules/module/module.scss",
+    "test/sass/another/variables.sass",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+"@charset "UTF-8";
+@import "./file.css";
+.module {
+  background: hotpink;
+}
+
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}"
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+{
+  "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
+  "names": [],
+  "sourceRoot": "",
+  "sources": [
+    "test/scss/language-source-maps.scss",
+    "test/node_modules/module/module.scss",
+    "test/scss/another/_variables.scss",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate sourcemap with "asset/resource" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
@@ -5836,7 +7173,7 @@ nav
 ",
     "$n-ary-summation: '\\2211'
 
-@import "sass-embedded-legacy-load-done:15"",
+@import "sass-embedded-legacy-load-done:17"",
   ],
   "version": 3,
 }

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -4954,7 +4954,7 @@ exports[`sourceMap option should generate source maps when value is not specifie
 
 exports[`sourceMap option should generate source maps when value is not specified and the "devtool" option has "source-map" value ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5014,9 +5014,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -5099,9 +5099,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5143,9 +5143,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -5217,9 +5217,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5279,9 +5279,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -5295,9 +5295,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('dart-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5339,9 +5339,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -5355,9 +5355,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('dart-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5417,9 +5417,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -5433,9 +5433,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('dart-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5477,9 +5477,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -5493,9 +5493,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('dart-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('dart-sass', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import url(./file.css);
 .module {
@@ -5546,9 +5546,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AEDP,AAAA,OAAO,CAAC;EACJ,UAAU,EAAE,OAAO,GACtB;;AFMD,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAKM;;AAE1B,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GAAG;;AAJvB,AAME,GANC,CAMD,EAAE,CAAC;EACD,OAAO,EAAE,YAAY,GAAG;;AAP5B,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GAAG;;AAQ5B,AAAA,IAAI,CAAC;EALH,qBAAqB,EAME,IAAI;EAL3B,kBAAkB,EAKK,IAAI;EAJ3B,iBAAiB,EAIM,IAAI;EAH3B,aAAa,EAGU,IAAI,GAAI;;AAEjC,AAAA,QAAQ,EAKR,QAAQ,EAIR,MAAM,EAIN,QAAQ,CAbC;EACP,MAAM,EAAE,cAAc;EACtB,OAAO,EAAE,IAAI;EACb,KAAK,EAAE,IAAI,GAAG;;AAEhB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,KAAK,GAAG;;AAExB,AAAA,MAAM,CAAC;EAEL,YAAY,EAAE,GAAG,GAAG;;AAEtB,AAAA,QAAQ,CAAC;EAEP,YAAY,EAAE,MAAM,GAAG;;AAEzB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAhDK,IAAO,GAgDJ;;AAEnB,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC1DO,IAAO,GD0DO",
   "names": [],
@@ -5631,9 +5631,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import url(./file.css);
 .module {
@@ -5670,9 +5670,9 @@ nav a {
 "
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACA,OAAO,CAAP,eAAO;AEDP,AAAA,OAAO,CAAC;EACJ,UAAU,EAAE,OAAO,GACtB;;AFMD,AAAA,IAAI,CAAC;EACH,IAAI,EAAE,IAAI,CALI,SAAS,EAAE,UAAU;EAMnC,KAAK,EALS,IAAI,GAMnB;;AAED,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB;;AAUH,AAAA,IAAI,CAAC;EANH,qBAAqB,EAMO,IAAI;EAL7B,kBAAkB,EAKO,IAAI;EAJ5B,iBAAiB,EAIO,IAAI;EAHxB,aAAa,EAGO,IAAI,GAAK;;AAEvC,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EAlCK,IAAO,GAmCpB;;AAGH,AACE,IADE,AACD,OAAO,CAAC;EACP,OAAO,EC9CO,IAAO,GD+CtB",
   "names": [],
@@ -5744,9 +5744,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('node-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('node-sass', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5806,9 +5806,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -5893,9 +5893,9 @@ nav
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -5937,9 +5937,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -6013,9 +6013,9 @@ nav {
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'legacy' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -6075,9 +6075,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -6091,9 +6091,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('sass-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -6135,9 +6135,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -6151,9 +6151,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('sass-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern' API, 'scss' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -6213,9 +6213,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AAQd;EACE;EACA;EACA;;AAEF;EACE;;AAEF;EACE;EACA;EACA;;;AAQJ;EALE,uBAMe;EALf,oBAKe;EAJf,mBAIe;EAHf,eAGe;;;AAEjB;EACE;EACA;EACA;;;AAEF;EAEE;;;AAEF;EAEE;;;AAEF;EAEE;;;AAGA;EACE,SAhDY;;;AAmDd;EACE,SE1Dc",
   "names": [],
@@ -6229,9 +6229,9 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('sass-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'sass' syntax): warnings 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): css 1`] = `
 "@charset "UTF-8";
 @import "./file.css";
 .module {
@@ -6273,9 +6273,9 @@ nav a {
 }"
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): errors 1`] = `[]`;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): source map 1`] = `
 {
   "mappings": ";AACQ;ACDR;EACI;;;ADOJ;EACE;EACA,OALc;;;AASd;EACE;EACA;EACA;;AAGF;EAAK;;AAEL;EACE;EACA;EACA;;;AAWJ;EANE,uBAM4B;EALzB,oBAKyB;EAJxB,mBAIwB;EAHpB,eAGoB;;;AAG5B;EACE,SAlCY;;;AAuCd;EACE,SE9Cc",
   "names": [],
@@ -6289,7 +6289,7 @@ exports[`sourceMap option should generate source maps with absoluve URLs ('sass-
 }
 `;
 
-exports[`sourceMap option should generate source maps with absoluve URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
+exports[`sourceMap option should generate source maps with absolute URLs ('sass-embedded', 'modern-compiler' API, 'scss' syntax): warnings 1`] = `[]`;
 
 exports[`sourceMap option should generate sourcemap with "asset/resource" ('dart-sass', 'legacy' API, 'sass' syntax): css 1`] = `
 "@charset "UTF-8";

--- a/test/sass/language-source-maps.sass
+++ b/test/sass/language-source-maps.sass
@@ -1,0 +1,60 @@
+@import "another/variables"
+@import "./file.css"
+@import "module"
+
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+$pi:            '\e0C6'
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none
+
+=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)
+
+.message
+  border: 1px solid #ccc
+  padding: 10px
+  color: #333
+
+.success
+  @extend .message
+  border-color: green
+
+.error
+  @extend .message
+  border-color: red
+
+.warning
+  @extend .message
+  border-color: yellow
+
+.foo
+  &:before
+    content: $pi
+
+.bar
+  &:before
+    content: $n-ary-summation
+

--- a/test/scss/language-source-maps.scss
+++ b/test/scss/language-source-maps.scss
@@ -1,0 +1,49 @@
+@import "another/variables";
+@import "./file.css";
+@import 'module';
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Generate correct sourceMaps when custom importer is used.

https://github.com/sass/sass/issues/3300

https://github.com/webpack-contrib/sass-loader/issues/1217

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
